### PR TITLE
fix(parameters): restore end-to-end parametric adjustments

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -49,7 +49,7 @@ export function createApp(dependencies: AppDependencies): Express {
   app.get('/api/health', (_request, response) => {
     response.json(healthResponse(runtime, runtimeError, python));
   });
-  registerSessionRoutes(app, paths);
+  registerSessionRoutes(app, paths, python);
   registerChatRoute(app, { python, runtime, runtimeError });
 
   if (existsSync(paths.distPath)) {

--- a/server/model-builds.ts
+++ b/server/model-builds.ts
@@ -1,0 +1,128 @@
+import { readFile } from 'node:fs/promises';
+import { basename, isAbsolute, relative, resolve, sep } from 'node:path';
+
+import type { ArtifactSummary } from '../src/types.ts';
+
+const BUILD_REPORT_SCHEMAS = new Set([
+  'evidence-cad-build/v2',
+  'evidence-color-build/v2',
+]);
+const MAX_BUILD_REPORT_BYTES = 2 * 1024 * 1024;
+
+interface ReportFileReference {
+  path?: unknown;
+}
+
+interface RawBuildReport {
+  artifacts?: Record<string, ReportFileReference>;
+  part?: unknown;
+  schema?: unknown;
+  source?: ReportFileReference | null;
+}
+
+export interface ModelBuild {
+  artifactPaths: string[];
+  modelId: string;
+  primaryPreviewPath: string;
+  reportPath: string;
+  sourcePath: string;
+}
+
+function safeRelativePath(root: string, value: string): string | undefined {
+  const candidate = isAbsolute(value) ? value : resolve(root, value);
+  const path = relative(root, candidate);
+  if (path === '' || path === '..' || path.startsWith(`..${sep}`)) {
+    return undefined;
+  }
+  return path.split(sep).join('/');
+}
+
+function artifactPathForReference(
+  root: string,
+  artifacts: readonly ArtifactSummary[],
+  value: unknown,
+  kind?: ArtifactSummary['kind'],
+): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const available = kind
+    ? artifacts.filter((artifact) => artifact.kind === kind)
+    : [...artifacts];
+  const relativePath = safeRelativePath(root, value);
+  if (
+    relativePath &&
+    available.some((artifact) => artifact.path === relativePath)
+  ) {
+    return relativePath;
+  }
+  const fileName = basename(value);
+  const matches = available.filter(
+    (artifact) => basename(artifact.path) === fileName,
+  );
+  return matches.length === 1 ? matches[0]?.path : undefined;
+}
+
+function reportArtifactPaths(
+  root: string,
+  artifacts: readonly ArtifactSummary[],
+  report: RawBuildReport,
+): string[] {
+  const paths = Object.values(report.artifacts ?? {})
+    .map((reference) =>
+      artifactPathForReference(root, artifacts, reference?.path, 'model'),
+    )
+    .filter((path): path is string => Boolean(path));
+  return [...new Set(paths)];
+}
+
+export async function discoverModelBuilds(
+  workspaceRoot: string,
+  artifacts: readonly ArtifactSummary[],
+): Promise<ModelBuild[]> {
+  const builds: ModelBuild[] = [];
+  for (const artifact of artifacts) {
+    if (
+      artifact.kind !== 'report' ||
+      !artifact.name.endsWith('_report.json') ||
+      artifact.size > MAX_BUILD_REPORT_BYTES
+    ) {
+      continue;
+    }
+    let report: RawBuildReport;
+    try {
+      report = JSON.parse(
+        await readFile(resolve(workspaceRoot, artifact.path), 'utf8'),
+      ) as RawBuildReport;
+    } catch {
+      continue;
+    }
+    if (!BUILD_REPORT_SCHEMAS.has(String(report.schema))) continue;
+    const sourcePath = artifactPathForReference(
+      workspaceRoot,
+      artifacts,
+      report.source?.path,
+      'source',
+    );
+    const primaryKey =
+      report.schema === 'evidence-color-build/v2' ? '3mf' : 'stl';
+    const primaryPreviewPath = artifactPathForReference(
+      workspaceRoot,
+      artifacts,
+      report.artifacts?.[primaryKey]?.path,
+      'model',
+    );
+    if (!sourcePath || !primaryPreviewPath) continue;
+    builds.push({
+      artifactPaths: reportArtifactPaths(workspaceRoot, artifacts, report),
+      modelId:
+        typeof report.part === 'string' && report.part.trim()
+          ? report.part
+          : basename(sourcePath, '.py'),
+      primaryPreviewPath,
+      reportPath: artifact.path,
+      sourcePath,
+    });
+  }
+  return builds.sort((left, right) =>
+    left.primaryPreviewPath.localeCompare(right.primaryPreviewPath),
+  );
+}

--- a/server/model-parameters.ts
+++ b/server/model-parameters.ts
@@ -1,0 +1,483 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { basename, dirname, join, resolve, sep } from 'node:path';
+
+import type {
+  ArtifactSummary,
+  ModelParameter,
+  ParameterModel,
+} from '../src/types.ts';
+import { scanArtifacts } from './artifacts.ts';
+import { discoverModelBuilds, type ModelBuild } from './model-builds.ts';
+
+const PARAMETER_SOURCE_SCRIPT = resolve(
+  import.meta.dirname,
+  'parameter_source.py',
+);
+const MAX_PROCESS_OUTPUT_BYTES = 2 * 1024 * 1024;
+const PARAMETER_BUILD_TIMEOUT_MS = 180_000;
+
+interface ParameterSourceResponse {
+  error?: string;
+  ok: boolean;
+  parameters?: ModelParameter[];
+  source?: string;
+}
+
+export interface ParameterBuildRequest {
+  primaryPreviewPath: string;
+  sourceHash: string;
+  sourcePath: string;
+  values: Record<string, number>;
+}
+
+export class ParameterBuildError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'ParameterBuildError';
+  }
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function safeTopLevelPath(path: string, label: string): string {
+  if (path !== basename(path) || dirname(path) !== '.') {
+    throw new ParameterBuildError(
+      `${label} must be a top-level session artifact.`,
+      400,
+    );
+  }
+  return path;
+}
+
+async function runJsonProcess(
+  executable: string,
+  args: string[],
+  input: unknown,
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+  } = {},
+): Promise<string> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(executable, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let outputBytes = 0;
+    let settled = false;
+    const finish = (error?: Error, output?: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) rejectPromise(error);
+      else resolvePromise(output ?? '');
+    };
+    const append = (target: 'stderr' | 'stdout', chunk: Buffer) => {
+      outputBytes += chunk.byteLength;
+      if (outputBytes > MAX_PROCESS_OUTPUT_BYTES) {
+        child.kill('SIGKILL');
+        finish(new Error('CAD parameter process produced too much output.'));
+        return;
+      }
+      if (target === 'stdout') stdout += chunk.toString('utf8');
+      else stderr += chunk.toString('utf8');
+    };
+    child.stdout.on('data', (chunk: Buffer) => append('stdout', chunk));
+    child.stderr.on('data', (chunk: Buffer) => append('stderr', chunk));
+    child.once('error', (error) => finish(error));
+    child.once('close', (code, signal) => {
+      if (code === 0) finish(undefined, stdout);
+      else {
+        const detail = (stderr || stdout).trim().slice(-4_000);
+        finish(
+          new Error(
+            detail ||
+              `CAD parameter process exited with ${signal ?? String(code)}.`,
+          ),
+        );
+      }
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(new Error('CAD parameter build timed out.'));
+    }, options.timeoutMs ?? 30_000);
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+async function parameterSource(
+  pythonExecutable: string,
+  input: Record<string, unknown>,
+): Promise<ParameterSourceResponse> {
+  let parsed: ParameterSourceResponse;
+  try {
+    parsed = JSON.parse(
+      await runJsonProcess(pythonExecutable, [PARAMETER_SOURCE_SCRIPT], input),
+    ) as ParameterSourceResponse;
+  } catch (error) {
+    throw new ParameterBuildError(
+      error instanceof Error ? error.message : 'Unable to inspect CAD source.',
+      422,
+    );
+  }
+  if (!parsed.ok) {
+    throw new ParameterBuildError(
+      parsed.error || 'Unable to inspect CAD source.',
+      422,
+    );
+  }
+  return parsed;
+}
+
+async function inspectSource(
+  pythonExecutable: string,
+  source: string,
+): Promise<ModelParameter[]> {
+  const response = await parameterSource(pythonExecutable, {
+    operation: 'inspect',
+    source,
+  });
+  if (!Array.isArray(response.parameters)) {
+    throw new ParameterBuildError(
+      'CAD parameter inspector returned no parameter list.',
+      422,
+    );
+  }
+  return response.parameters;
+}
+
+async function rewriteSource(
+  pythonExecutable: string,
+  source: string,
+  values: Record<string, number>,
+): Promise<string> {
+  const response = await parameterSource(pythonExecutable, {
+    operation: 'rewrite',
+    source,
+    values,
+  });
+  if (typeof response.source !== 'string') {
+    throw new ParameterBuildError(
+      'CAD parameter rewriter returned no source.',
+      422,
+    );
+  }
+  return response.source;
+}
+
+export function parseParameterBuildRequest(
+  value: unknown,
+): ParameterBuildRequest | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as Partial<ParameterBuildRequest>;
+  if (
+    typeof candidate.sourcePath !== 'string' ||
+    candidate.sourcePath.length === 0 ||
+    candidate.sourcePath.length > 1_024 ||
+    typeof candidate.primaryPreviewPath !== 'string' ||
+    candidate.primaryPreviewPath.length === 0 ||
+    candidate.primaryPreviewPath.length > 1_024 ||
+    typeof candidate.sourceHash !== 'string' ||
+    !/^[a-f0-9]{64}$/u.test(candidate.sourceHash) ||
+    !candidate.values ||
+    typeof candidate.values !== 'object' ||
+    Array.isArray(candidate.values)
+  ) {
+    return undefined;
+  }
+  const entries = Object.entries(candidate.values);
+  if (
+    entries.length === 0 ||
+    entries.length > 100 ||
+    entries.some(
+      ([id, parameterValue]) =>
+        id.length === 0 ||
+        id.length > 160 ||
+        typeof parameterValue !== 'number' ||
+        !Number.isFinite(parameterValue),
+    )
+  ) {
+    return undefined;
+  }
+  return candidate as ParameterBuildRequest;
+}
+
+export async function parameterModelsForWorkspace(
+  workspaceRoot: string,
+  pythonExecutable: string,
+  artifacts?: readonly ArtifactSummary[],
+): Promise<ParameterModel[]> {
+  const availableArtifacts = artifacts ?? (await scanArtifacts(workspaceRoot));
+  const builds = await discoverModelBuilds(workspaceRoot, availableArtifacts);
+  return Promise.all(
+    builds.map(async (build) => {
+      const source = await readFile(resolve(workspaceRoot, build.sourcePath), 'utf8');
+      try {
+        return {
+          ...build,
+          parameters: await inspectSource(pythonExecutable, source),
+          sourceHash: sha256(source),
+        };
+      } catch (error) {
+        return {
+          ...build,
+          parameterError:
+            error instanceof Error
+              ? error.message
+              : 'Unable to inspect model parameters.',
+          parameters: [],
+          sourceHash: sha256(source),
+        };
+      }
+    }),
+  );
+}
+
+async function requireCandidateFiles(
+  outDir: string,
+  build: ModelBuild,
+): Promise<string[]> {
+  const paths = [...new Set([...build.artifactPaths, build.reportPath])];
+  for (const path of paths) {
+    safeTopLevelPath(path, 'Generated artifact');
+    try {
+      const metadata = await stat(join(outDir, path));
+      if (!metadata.isFile()) throw new Error('not a file');
+    } catch {
+      throw new ParameterBuildError(
+        `Parameter build did not regenerate ${path}.`,
+        422,
+      );
+    }
+  }
+  if (!paths.includes(build.primaryPreviewPath)) {
+    throw new ParameterBuildError(
+      'Parameter build report does not own the selected top-level preview.',
+      409,
+    );
+  }
+  return paths;
+}
+
+function rebaseReportPaths(
+  value: unknown,
+  outDir: string,
+  workspaceRoot: string,
+): unknown {
+  if (typeof value === 'string') {
+    const prefix = `${outDir}${sep}`;
+    return value.startsWith(prefix)
+      ? join(workspaceRoot, value.slice(prefix.length))
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => rebaseReportPaths(item, outDir, workspaceRoot));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        rebaseReportPaths(item, outDir, workspaceRoot),
+      ]),
+    );
+  }
+  return value;
+}
+
+async function prepareCandidateReport(
+  reportPath: string,
+  outDir: string,
+  workspaceRoot: string,
+  sourcePath: string,
+  sourceHash: string,
+  values: Record<string, number>,
+): Promise<void> {
+  const raw = JSON.parse(await readFile(reportPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  const report = rebaseReportPaths(raw, outDir, workspaceRoot) as Record<
+    string,
+    unknown
+  >;
+  report.source = {
+    path: join(workspaceRoot, sourcePath),
+    sha256: sourceHash,
+  };
+  if (report.parameters && typeof report.parameters === 'object') {
+    const parameters = report.parameters as Record<
+      string,
+      Record<string, unknown>
+    >;
+    for (const [id, parameterValue] of Object.entries(values)) {
+      if (parameters[id]) {
+        parameters[id].default = parameterValue;
+        parameters[id].value = parameterValue;
+      }
+    }
+  }
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}
+
+async function promoteFiles(
+  files: Array<{ from: string; to: string }>,
+  backupDir: string,
+): Promise<void> {
+  await mkdir(backupDir, { recursive: true });
+  const backups: Array<{ from: string; to: string }> = [];
+  const installed: string[] = [];
+  try {
+    for (const [index, file] of files.entries()) {
+      try {
+        await stat(file.to);
+      } catch {
+        continue;
+      }
+      const backup = join(backupDir, `${String(index)}-${basename(file.to)}`);
+      await rename(file.to, backup);
+      backups.push({ from: backup, to: file.to });
+    }
+    for (const file of files) {
+      await rename(file.from, file.to);
+      installed.push(file.to);
+    }
+  } catch (error) {
+    await Promise.all(installed.map((path) => rm(path, { force: true })));
+    for (const backup of [...backups].reverse()) {
+      await rename(backup.from, backup.to).catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
+async function executeParameterBuild(
+  pythonExecutable: string,
+  sourcePath: string,
+  workspaceRoot: string,
+  outDir: string,
+  values: Record<string, number>,
+): Promise<void> {
+  try {
+    await runJsonProcess(
+      pythonExecutable,
+      [sourcePath],
+      {},
+      {
+        cwd: workspaceRoot,
+        env: {
+          ...process.env,
+          AMAGINE3D_OUTPUT_DIR: outDir,
+          AMAGINE3D_PARAMETER_OVERRIDES: JSON.stringify(values),
+          MPLBACKEND: 'Agg',
+          PYTHONDONTWRITEBYTECODE: '1',
+        },
+        timeoutMs: PARAMETER_BUILD_TIMEOUT_MS,
+      },
+    );
+  } catch (error) {
+    throw new ParameterBuildError(
+      error instanceof Error ? error.message : 'Parameter build failed.',
+      422,
+    );
+  }
+}
+
+export async function rebuildModelWithParameters(options: {
+  pythonExecutable: string;
+  request: ParameterBuildRequest;
+  workspaceRoot: string;
+}): Promise<void> {
+  const { pythonExecutable, request, workspaceRoot } = options;
+  safeTopLevelPath(request.sourcePath, 'Model source');
+  safeTopLevelPath(request.primaryPreviewPath, 'Top-level preview');
+  const artifacts = await scanArtifacts(workspaceRoot);
+  const build = (await discoverModelBuilds(workspaceRoot, artifacts)).find(
+    (candidate) =>
+      candidate.sourcePath === request.sourcePath &&
+      candidate.primaryPreviewPath === request.primaryPreviewPath,
+  );
+  if (!build) {
+    throw new ParameterBuildError(
+      'The selected artifact is not a recognized top-level model preview.',
+      409,
+    );
+  }
+  build.artifactPaths.forEach((path) => safeTopLevelPath(path, 'Model artifact'));
+  safeTopLevelPath(build.reportPath, 'Build report');
+  const sourcePath = join(workspaceRoot, request.sourcePath);
+  const source = await readFile(sourcePath, 'utf8');
+  if (sha256(source) !== request.sourceHash) {
+    throw new ParameterBuildError(
+      'Model source changed; reload parameters before rebuilding.',
+      409,
+    );
+  }
+  const rewrittenSource = await rewriteSource(
+    pythonExecutable,
+    source,
+    request.values,
+  );
+  const rewrittenSourceHash = sha256(rewrittenSource);
+  const buildsRoot = join(
+    workspaceRoot,
+    '.amagine-state',
+    'parameter-builds',
+  );
+  await mkdir(buildsRoot, { recursive: true });
+  const jobRoot = await mkdtemp(join(buildsRoot, 'job-'));
+  const outDir = join(jobRoot, 'out');
+  const backupDir = join(jobRoot, 'backup');
+  const stagedSourcePath = join(jobRoot, basename(request.sourcePath));
+  await mkdir(outDir, { recursive: true });
+  try {
+    await executeParameterBuild(
+      pythonExecutable,
+      sourcePath,
+      workspaceRoot,
+      outDir,
+      request.values,
+    );
+    const candidatePaths = await requireCandidateFiles(outDir, build);
+    const candidateReportPath = join(outDir, build.reportPath);
+    await prepareCandidateReport(
+      candidateReportPath,
+      outDir,
+      workspaceRoot,
+      request.sourcePath,
+      rewrittenSourceHash,
+      request.values,
+    );
+    await writeFile(stagedSourcePath, rewrittenSource, 'utf8');
+    await promoteFiles(
+      [
+        ...candidatePaths.map((path) => ({
+          from: join(outDir, path),
+          to: join(workspaceRoot, path),
+        })),
+        { from: stagedSourcePath, to: sourcePath },
+      ],
+      backupDir,
+    );
+  } finally {
+    await rm(jobRoot, { force: true, recursive: true });
+  }
+}

--- a/server/parameter_source.py
+++ b/server/parameter_source.py
@@ -1,0 +1,229 @@
+"""Inspect and rewrite explicit parameter() declarations without executing source."""
+
+from __future__ import annotations
+
+import ast
+import json
+import math
+import re
+import sys
+
+
+ALLOWED_KEYWORDS = {
+    "affects",
+    "group",
+    "group_zh",
+    "label",
+    "label_zh",
+    "max_value",
+    "min_value",
+    "step",
+    "unit",
+}
+
+
+def numeric_literal(node: ast.AST) -> int | float:
+    if isinstance(node, ast.Constant):
+        value = node.value
+    elif (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, (ast.UAdd, ast.USub))
+        and isinstance(node.operand, ast.Constant)
+    ):
+        operand = node.operand.value
+        if isinstance(operand, bool) or not isinstance(operand, (int, float)):
+            raise ValueError("parameter defaults and bounds must be numeric literals")
+        value = operand if isinstance(node.op, ast.UAdd) else -operand
+    else:
+        raise ValueError("parameter defaults and bounds must be numeric literals")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("parameter defaults and bounds must be numeric literals")
+    if not math.isfinite(value):
+        raise ValueError("parameter defaults and bounds must be finite")
+    return value
+
+
+def string_literal(node: ast.AST, field: str) -> str:
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        raise ValueError(f"parameter {field} must be a string literal")
+    return node.value
+
+
+def affects_literal(node: ast.AST) -> list[str]:
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        raise ValueError("parameter affects must be a list or tuple of strings")
+    values = [string_literal(item, "affects") for item in node.elts]
+    if len(values) != len(set(values)):
+        raise ValueError("parameter affects cannot contain duplicate feature IDs")
+    return values
+
+
+def optional_localized_string(node: ast.AST | None) -> str | None:
+    """Return usable localized metadata without making it build-critical."""
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        return None
+    value = node.value.strip()
+    return value or None
+
+
+def source_offset(source: str, lineno: int, byte_column: int) -> int:
+    lines = source.splitlines(keepends=True)
+    line = lines[lineno - 1]
+    prefix = line.encode("utf-8")[:byte_column].decode("utf-8")
+    return sum(len(item) for item in lines[: lineno - 1]) + len(prefix)
+
+
+def declarations(source: str) -> list[dict]:
+    tree = ast.parse(source, filename="model.py")
+    result: list[dict] = []
+    ids: set[str] = set()
+    names: set[str] = set()
+    for statement in tree.body:
+        name = None
+        value_node = None
+        if (
+            isinstance(statement, ast.Assign)
+            and len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+        ):
+            name, value_node = statement.targets[0].id, statement.value
+        elif isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+            name, value_node = statement.target.id, statement.value
+        if (
+            name is None
+            or not isinstance(value_node, ast.Call)
+            or not isinstance(value_node.func, ast.Name)
+            or value_node.func.id != "parameter"
+        ):
+            continue
+        if len(value_node.args) != 2:
+            raise ValueError(f"{name}: parameter() requires ID and default positional arguments")
+        if any(keyword.arg is None for keyword in value_node.keywords):
+            raise ValueError(f"{name}: parameter() does not accept expanded keywords")
+        keywords = {keyword.arg: keyword.value for keyword in value_node.keywords}
+        unknown = set(keywords) - ALLOWED_KEYWORDS
+        if unknown:
+            raise ValueError(f"{name}: unknown parameter metadata {sorted(unknown)}")
+        required = {"min_value", "max_value", "step"}
+        missing = required - set(keywords)
+        if missing:
+            raise ValueError(f"{name}: missing parameter metadata {sorted(missing)}")
+
+        parameter_id = string_literal(value_node.args[0], "ID")
+        default_node = value_node.args[1]
+        default = numeric_literal(default_node)
+        minimum = numeric_literal(keywords["min_value"])
+        maximum = numeric_literal(keywords["max_value"])
+        step = numeric_literal(keywords["step"])
+        if not re.fullmatch(r"[a-z][a-z0-9_-]*", parameter_id) or parameter_id in ids:
+            raise ValueError(f"{name}: parameter IDs must be non-empty and unique")
+        if name in names:
+            raise ValueError(f"{name}: parameter variable names must be unique")
+        if minimum > maximum:
+            raise ValueError(f"{name}: min_value cannot exceed max_value")
+        if default < minimum or default > maximum:
+            raise ValueError(f"{name}: default must be inside its declared bounds")
+        if step <= 0:
+            raise ValueError(f"{name}: step must be positive")
+        kind = "integer" if isinstance(default, int) else "number"
+        descriptor = {
+            "affects": affects_literal(keywords["affects"])
+            if "affects" in keywords
+            else [],
+            "defaultValue": default,
+            "id": parameter_id,
+            "kind": kind,
+            "label": string_literal(keywords["label"], "label")
+            if "label" in keywords
+            else name,
+            "maximum": maximum,
+            "minimum": minimum,
+            "name": name,
+            "step": step,
+            "value": default,
+            "_start": source_offset(source, default_node.lineno, default_node.col_offset),
+            "_end": source_offset(
+                source, default_node.end_lineno, default_node.end_col_offset
+            ),
+        }
+        if "group" in keywords:
+            descriptor["group"] = string_literal(keywords["group"], "group")
+        group_zh = optional_localized_string(keywords.get("group_zh"))
+        if group_zh:
+            descriptor["groupZh"] = group_zh
+        label_zh = optional_localized_string(keywords.get("label_zh"))
+        if label_zh:
+            descriptor["labelZh"] = label_zh
+        if "unit" in keywords:
+            descriptor["unit"] = string_literal(keywords["unit"], "unit")
+        result.append(descriptor)
+        ids.add(parameter_id)
+        names.add(name)
+    return result
+
+
+def public_descriptor(item: dict) -> dict:
+    return {key: value for key, value in item.items() if not key.startswith("_")}
+
+
+def validate_value(item: dict, value) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{item['id']}: override must be numeric")
+    if not math.isfinite(value):
+        raise ValueError(f"{item['id']}: override must be finite")
+    if item["kind"] == "integer" and not isinstance(value, int):
+        raise ValueError(f"{item['id']}: override must be an integer")
+    if value < item["minimum"] or value > item["maximum"]:
+        raise ValueError(f"{item['id']}: override is outside its declared bounds")
+    quotient = (value - item["minimum"]) / item["step"]
+    if not math.isclose(quotient, round(quotient), abs_tol=1e-8):
+        raise ValueError(f"{item['id']}: override does not align with its step")
+    return value
+
+
+def rewrite(source: str, values: dict) -> str:
+    items = declarations(source)
+    by_id = {item["id"]: item for item in items}
+    unknown = set(values) - set(by_id)
+    if unknown:
+        raise ValueError(f"unknown parameter IDs: {sorted(unknown)}")
+    replacements = []
+    for parameter_id, raw_value in values.items():
+        item = by_id[parameter_id]
+        value = validate_value(item, raw_value)
+        literal = repr(int(value)) if item["kind"] == "integer" else repr(float(value))
+        replacements.append((item["_start"], item["_end"], literal))
+    rewritten = source
+    for start, end, literal in sorted(replacements, reverse=True):
+        rewritten = rewritten[:start] + literal + rewritten[end:]
+    declarations(rewritten)
+    return rewritten
+
+
+def main() -> int:
+    try:
+        request = json.load(sys.stdin)
+        source = request["source"]
+        operation = request.get("operation", "inspect")
+        if not isinstance(source, str):
+            raise ValueError("source must be a string")
+        if operation == "inspect":
+            response = {
+                "parameters": [public_descriptor(item) for item in declarations(source)]
+            }
+        elif operation == "rewrite":
+            values = request.get("values")
+            if not isinstance(values, dict):
+                raise ValueError("values must be an object")
+            response = {"source": rewrite(source, values)}
+        else:
+            raise ValueError(f"unsupported operation: {operation}")
+        print(json.dumps({"ok": True, **response}, ensure_ascii=False))
+        return 0
+    except Exception as error:
+        print(json.dumps({"ok": False, "error": str(error)}, ensure_ascii=False))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -21,6 +21,7 @@ import type {
 import { assistantMessageOutcome } from '../agent-events.ts';
 import { durationFromEnv, errorMessage } from '../http-utils.ts';
 import { isChatRequest } from '../protocol.ts';
+import { acquireSessionActivity } from '../session-activity.ts';
 import { userSessionArtifacts } from '../sessions.ts';
 import { appendSavedImageContext, saveImageAttachments } from '../uploads.ts';
 import {
@@ -34,7 +35,6 @@ import {
   webSearchRepairInstruction,
 } from '../web-search.ts';
 
-const activeSessionIds = new Set<string>();
 const MAX_VISUAL_REPAIR_ATTEMPTS = 3;
 const MAX_WEB_SEARCH_REPAIR_ATTEMPTS = 2;
 
@@ -130,13 +130,13 @@ export function registerChatRoute(
       });
       return;
     }
-    if (activeSessionIds.has(sessionId)) {
+    const releaseSession = acquireSessionActivity(sessionId);
+    if (!releaseSession) {
       response.status(409).json({
         message: 'This session already has an active turn.',
       });
       return;
     }
-    activeSessionIds.add(sessionId);
 
     response.status(200);
     response.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
@@ -424,7 +424,7 @@ export function registerChatRoute(
       response.off('close', abortForDisconnect);
       unsubscribe?.();
       session?.dispose();
-      activeSessionIds.delete(sessionId);
+      releaseSession();
       if (!response.writableEnded && !response.destroyed) response.end();
     }
   });

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,6 +1,9 @@
 import type { Express } from 'express';
 
-import { BUNDLED_POMODORO_SESSION_ID } from '../../src/types.ts';
+import {
+  BUNDLED_POMODORO_SESSION_ID,
+  type PythonHealth,
+} from '../../src/types.ts';
 import {
   createArtifactArchive,
   MAX_ARCHIVE_FILES,
@@ -15,6 +18,13 @@ import {
   resolveArtifactPath,
 } from '../artifacts.ts';
 import { bundledPomodoroArtifacts } from '../bundled-workspace.ts';
+import {
+  ParameterBuildError,
+  parameterModelsForWorkspace,
+  parseParameterBuildRequest,
+  rebuildModelWithParameters,
+} from '../model-parameters.ts';
+import { acquireSessionActivity } from '../session-activity.ts';
 import {
   artifactsForSession,
   BUILTIN_POMODORO_SESSION,
@@ -34,6 +44,7 @@ export interface SessionRoutePaths {
 export function registerSessionRoutes(
   app: Express,
   paths: SessionRoutePaths,
+  python: PythonHealth,
 ): void {
   app.get('/api/sessions', async (_request, response) => {
     response.json(await listSessionCatalog(paths.sessionRoot));
@@ -84,6 +95,104 @@ export function registerSessionRoutes(
     }
     response.json(collection);
   });
+
+  app.get('/api/sessions/:sessionId/parameters', async (request, response) => {
+    if (request.params.sessionId === BUNDLED_POMODORO_SESSION_ID) {
+      response.json({ models: [] });
+      return;
+    }
+    const workspaceRoot = sessionWorkspaceRoot(
+      paths.workspaceRoot,
+      request.params.sessionId,
+    );
+    if (!workspaceRoot) {
+      response.status(400).json({ message: 'Invalid session id.' });
+      return;
+    }
+    if (!python.ready || !python.executable) {
+      response.status(503).json({ message: 'Python CAD runtime is not ready.' });
+      return;
+    }
+    try {
+      const collection = await userSessionArtifacts(
+        paths.workspaceRoot,
+        request.params.sessionId,
+      );
+      response.json({
+        models: await parameterModelsForWorkspace(
+          workspaceRoot,
+          python.executable,
+          collection?.artifacts,
+        ),
+      });
+    } catch (error) {
+      response.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Unable to inspect model parameters.',
+      });
+    }
+  });
+
+  app.post(
+    '/api/sessions/:sessionId/parameters/rebuild',
+    async (request, response) => {
+      if (request.params.sessionId === BUNDLED_POMODORO_SESSION_ID) {
+        response.status(403).json({ message: 'Built-in projects are read-only.' });
+        return;
+      }
+      const workspaceRoot = sessionWorkspaceRoot(
+        paths.workspaceRoot,
+        request.params.sessionId,
+      );
+      const buildRequest = parseParameterBuildRequest(request.body);
+      if (!workspaceRoot || !buildRequest) {
+        response.status(400).json({ message: 'Invalid parameter build request.' });
+        return;
+      }
+      if (!python.ready || !python.executable) {
+        response.status(503).json({ message: 'Python CAD runtime is not ready.' });
+        return;
+      }
+      const releaseSession = acquireSessionActivity(request.params.sessionId);
+      if (!releaseSession) {
+        response.status(409).json({
+          message: 'This session already has an active CAD operation.',
+        });
+        return;
+      }
+      try {
+        await rebuildModelWithParameters({
+          pythonExecutable: python.executable,
+          request: buildRequest,
+          workspaceRoot,
+        });
+        const collection = await userSessionArtifacts(
+          paths.workspaceRoot,
+          request.params.sessionId,
+        );
+        if (!collection) {
+          throw new ParameterBuildError('Invalid session id.', 400);
+        }
+        response.json({
+          ...collection,
+          models: await parameterModelsForWorkspace(
+            workspaceRoot,
+            python.executable,
+            collection.artifacts,
+          ),
+        });
+      } catch (error) {
+        response.status(error instanceof ParameterBuildError ? error.status : 500).json({
+          message:
+            error instanceof Error ? error.message : 'Parameter build failed.',
+        });
+      } finally {
+        releaseSession();
+      }
+    },
+  );
 
   app.get('/api/sessions/:sessionId/artifacts/file', async (request, response) => {
     const scopedWorkspaceRoot = sessionWorkspaceRoot(

--- a/server/session-activity.ts
+++ b/server/session-activity.ts
@@ -1,0 +1,14 @@
+const activeSessionIds = new Set<string>();
+
+export function acquireSessionActivity(
+  sessionId: string,
+): (() => void) | undefined {
+  if (activeSessionIds.has(sessionId)) return undefined;
+  activeSessionIds.add(sessionId);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activeSessionIds.delete(sessionId);
+  };
+}

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -16,6 +16,7 @@ import {
 } from '../src/types.ts';
 import { scanArtifacts } from './artifacts.ts';
 import { bundledPomodoroArtifacts } from './bundled-workspace.ts';
+import { discoverModelBuilds } from './model-builds.ts';
 import {
   restoredChatStages,
   RUN_STAGES_CUSTOM_TYPE,
@@ -157,8 +158,15 @@ export async function userSessionArtifacts(
 ): Promise<ArtifactCollection | undefined> {
   const root = sessionWorkspaceRoot(workspaceRoot, sessionId);
   if (!root) return undefined;
-  const artifacts = (await scanArtifacts(root)).map((artifact) => ({
+  const scannedArtifacts = await scanArtifacts(root);
+  const featuredPaths = new Set(
+    (await discoverModelBuilds(root, scannedArtifacts)).map(
+      ({ primaryPreviewPath }) => primaryPreviewPath,
+    ),
+  );
+  const artifacts = scannedArtifacts.map((artifact) => ({
     ...artifact,
+    ...(featuredPaths.has(artifact.path) ? { featured: true } : {}),
     url: `/api/sessions/${encodeURIComponent(sessionId)}/artifacts/file?path=${encodeURIComponent(artifact.path)}`,
   }));
   return {

--- a/skills/text-a3d-color/SKILL.md
+++ b/skills/text-a3d-color/SKILL.md
@@ -90,10 +90,17 @@ IDs:
 import sys
 sys.path.insert(0, r"<SKILL_DIR>")
 from build123d import *
-from cad_helpers import observe, checked_cut, export_regions
+from cad_helpers import parameter, observe, checked_cut, export_regions
 
 NAME = "<name>"
 INTENT = "<name>_intent.json"
+WIDTH = parameter(
+    "overall-width", 80.0,
+    min_value=48.0, max_value=140.0, step=0.5,
+    unit="mm", label="Overall width", label_zh="总体宽度",
+    group="Envelope", group_zh="外形尺寸",
+    affects=("complete-parent",),
+)
 parent = ...
 observe(parent, "complete-parent", "parent")
 
@@ -109,6 +116,17 @@ if __name__ == "__main__":
 
 For separately assembled inserts whose union intentionally differs from one
 parent, omit `parent=` only after recording that architecture in the contract.
+
+Expose every meaningful user-adjustable driving dimension with `parameter()`:
+overall dimensions plus local feature, interface, inset, clearance, and region
+boundary dimensions. Give each one a stable ID, conservative topology-safe
+bounds, a positive step, unit, label, group, and the feature or region IDs it
+affects. Add concise `label_zh` and `group_zh` translations while keeping IDs and
+Python variable names stable in English. Localized fields are presentation
+metadata only. Derived coordinates and palette values are not independent
+slider parameters. Every override must rebuild the entire region set and
+combined 3MF; never publish a parameter that is unused by the full model
+construction.
 
 ## 4. Audit meshes, archive, and appearance
 

--- a/skills/text-a3d-color/cad_helpers.py
+++ b/skills/text-a3d-color/cad_helpers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from hashlib import sha256
 import json
+import math
+import os
 from pathlib import Path
 import re
 import sys
@@ -20,8 +22,78 @@ class RegionInvariantError(RuntimeError):
 
 _FEATURES: dict[str, dict] = {}
 _OPERATIONS: list[dict] = []
+_PARAMETERS: dict[str, dict] = {}
 _REGION_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
 _HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
+_PARAMETER_ID = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _parameter_overrides() -> dict:
+    raw = os.environ.get("AMAGINE3D_PARAMETER_OVERRIDES", "{}").strip() or "{}"
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise RegionInvariantError("invalid parameter override payload") from error
+    if not isinstance(value, dict):
+        raise RegionInvariantError("parameter overrides must be an object")
+    return value
+
+
+def parameter(
+    parameter_id: str,
+    default: int | float,
+    *,
+    min_value: int | float,
+    max_value: int | float,
+    step: int | float,
+    unit: str | None = None,
+    label: str | None = None,
+    label_zh: str | None = None,
+    group: str | None = None,
+    group_zh: str | None = None,
+    affects: tuple[str, ...] | list[str] = (),
+) -> int | float:
+    """Declare one bounded user-adjustable driving value."""
+    if not _PARAMETER_ID.fullmatch(parameter_id) or parameter_id in _PARAMETERS:
+        raise RegionInvariantError(f"invalid or duplicate parameter id: {parameter_id!r}")
+    numbers = (default, min_value, max_value, step)
+    if any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in numbers):
+        raise RegionInvariantError(f"parameter {parameter_id!r} must be numeric")
+    if any(not math.isfinite(value) for value in numbers):
+        raise RegionInvariantError(f"parameter {parameter_id!r} must be finite")
+    if min_value > max_value or not min_value <= default <= max_value or step <= 0:
+        raise RegionInvariantError(f"parameter {parameter_id!r} has invalid bounds")
+    overrides = _parameter_overrides()
+    value = overrides.get(parameter_id, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RegionInvariantError(f"parameter {parameter_id!r} override must be numeric")
+    if isinstance(default, int) and not isinstance(value, int):
+        raise RegionInvariantError(f"parameter {parameter_id!r} override must be an integer")
+    if not math.isfinite(value) or not min_value <= value <= max_value:
+        raise RegionInvariantError(f"parameter {parameter_id!r} override is out of bounds")
+    quotient = (value - min_value) / step
+    if not math.isclose(quotient, round(quotient), abs_tol=1e-8):
+        raise RegionInvariantError(f"parameter {parameter_id!r} override does not align with step")
+    feature_ids = list(affects)
+    if any(not isinstance(feature_id, str) or not feature_id for feature_id in feature_ids):
+        raise RegionInvariantError(f"parameter {parameter_id!r} has invalid feature IDs")
+    descriptor = {
+        "affects": feature_ids,
+        "default": default,
+        "group": group,
+        "label": label or parameter_id,
+        "maximum": max_value,
+        "minimum": min_value,
+        "step": step,
+        "unit": unit,
+        "value": value,
+    }
+    if isinstance(label_zh, str) and label_zh.strip():
+        descriptor["label_zh"] = label_zh.strip()
+    if isinstance(group_zh, str) and group_zh.strip():
+        descriptor["group_zh"] = group_zh.strip()
+    _PARAMETERS[parameter_id] = descriptor
+    return value
 
 
 def _digest(path: Path) -> str:
@@ -121,13 +193,14 @@ def export_regions(
     if len(regions) < 2:
         raise RegionInvariantError("multi-color output requires at least two regions")
 
-    output = Path(out_dir)
+    output = Path(os.environ.get("AMAGINE3D_OUTPUT_DIR", out_dir))
     output.mkdir(parents=True, exist_ok=True)
     report = {
         "built_at": datetime.now(timezone.utc).isoformat(),
         "features": dict(_FEATURES),
         "operations": list(_OPERATIONS),
         "overlaps_mm3": {},
+        "parameters": dict(_PARAMETERS),
         "part": name,
         "regions": {},
         "schema": "evidence-color-build/v2",

--- a/skills/text-a3d/SKILL.md
+++ b/skills/text-a3d/SKILL.md
@@ -86,10 +86,17 @@ contract feature IDs. New sources use this runtime shape:
 import sys
 sys.path.insert(0, r"<SKILL_DIR>")
 from build123d import *
-from cad_helpers import observe, checked_cut, checked_fillet, export_part
+from cad_helpers import parameter, observe, checked_cut, checked_fillet, export_part
 
 NAME = "<name>"
 INTENT = "<name>_intent.json"
+WIDTH = parameter(
+    "overall-width", 40.0,
+    min_value=24.0, max_value=80.0, step=0.5,
+    unit="mm", label="Overall width", label_zh="总体宽度",
+    group="Envelope", group_zh="外形尺寸",
+    affects=("primary-envelope",),
+)
 
 # primary envelope -> identity volumes -> cuts -> controls -> finishes
 body = ...
@@ -107,6 +114,17 @@ if __name__ == "__main__":
 Checked operations raise instead of silently returning unchanged geometry.
 Finishing degradation is forbidden unless the contract permits it; if allowed,
 the actual size appears in the build report.
+
+Expose every meaningful user-adjustable driving dimension with `parameter()`:
+overall dimensions, local feature sizes and positions, clearances, wall
+thicknesses, hole diameters, and finish sizes when applicable. Give each one a
+stable ID, conservative topology-safe bounds, a positive step, unit, label,
+group, concise `label_zh` and `group_zh` translations, and the contract feature
+IDs it affects. Localized fields are presentation metadata only: keep IDs and
+Python variable names stable in English. Derived coordinates remain ordinary
+expressions and must not be exposed as independent controls. A parameter change
+rebuilds and republishes the complete model, so never declare an output-only or
+unused value.
 
 ## 4. Prove geometry, then appearance
 

--- a/skills/text-a3d/cad_helpers.py
+++ b/skills/text-a3d/cad_helpers.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from hashlib import sha256
 import json
+import math
+import os
 from pathlib import Path
+import re
 import sys
 from typing import Callable, Iterable
 
@@ -23,6 +26,76 @@ class BuildInvariantError(RuntimeError):
 
 _EVENTS: list[dict] = []
 _FEATURES: dict[str, dict] = {}
+_PARAMETERS: dict[str, dict] = {}
+_PARAMETER_ID = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _parameter_overrides() -> dict:
+    raw = os.environ.get("AMAGINE3D_PARAMETER_OVERRIDES", "{}").strip() or "{}"
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise BuildInvariantError("invalid parameter override payload") from error
+    if not isinstance(value, dict):
+        raise BuildInvariantError("parameter overrides must be an object")
+    return value
+
+
+def parameter(
+    parameter_id: str,
+    default: int | float,
+    *,
+    min_value: int | float,
+    max_value: int | float,
+    step: int | float,
+    unit: str | None = None,
+    label: str | None = None,
+    label_zh: str | None = None,
+    group: str | None = None,
+    group_zh: str | None = None,
+    affects: tuple[str, ...] | list[str] = (),
+) -> int | float:
+    """Declare one bounded user-adjustable driving value."""
+    if not _PARAMETER_ID.fullmatch(parameter_id) or parameter_id in _PARAMETERS:
+        raise BuildInvariantError(f"invalid or duplicate parameter id: {parameter_id!r}")
+    numbers = (default, min_value, max_value, step)
+    if any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in numbers):
+        raise BuildInvariantError(f"parameter {parameter_id!r} must be numeric")
+    if any(not math.isfinite(value) for value in numbers):
+        raise BuildInvariantError(f"parameter {parameter_id!r} must be finite")
+    if min_value > max_value or not min_value <= default <= max_value or step <= 0:
+        raise BuildInvariantError(f"parameter {parameter_id!r} has invalid bounds")
+    overrides = _parameter_overrides()
+    value = overrides.get(parameter_id, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BuildInvariantError(f"parameter {parameter_id!r} override must be numeric")
+    if isinstance(default, int) and not isinstance(value, int):
+        raise BuildInvariantError(f"parameter {parameter_id!r} override must be an integer")
+    if not math.isfinite(value) or not min_value <= value <= max_value:
+        raise BuildInvariantError(f"parameter {parameter_id!r} override is out of bounds")
+    quotient = (value - min_value) / step
+    if not math.isclose(quotient, round(quotient), abs_tol=1e-8):
+        raise BuildInvariantError(f"parameter {parameter_id!r} override does not align with step")
+    feature_ids = list(affects)
+    if any(not isinstance(feature_id, str) or not feature_id for feature_id in feature_ids):
+        raise BuildInvariantError(f"parameter {parameter_id!r} has invalid feature IDs")
+    descriptor = {
+        "affects": feature_ids,
+        "default": default,
+        "group": group,
+        "label": label or parameter_id,
+        "maximum": max_value,
+        "minimum": min_value,
+        "step": step,
+        "unit": unit,
+        "value": value,
+    }
+    if isinstance(label_zh, str) and label_zh.strip():
+        descriptor["label_zh"] = label_zh.strip()
+    if isinstance(group_zh, str) and group_zh.strip():
+        descriptor["group_zh"] = group_zh.strip()
+    _PARAMETERS[parameter_id] = descriptor
+    return value
 
 
 def _digest(path: Path) -> str:
@@ -156,7 +229,7 @@ def export_part(
             f"final shape must be one valid solid, got {stats['solid_count']}"
         )
 
-    output = Path(out_dir)
+    output = Path(os.environ.get("AMAGINE3D_OUTPUT_DIR", out_dir))
     output.mkdir(parents=True, exist_ok=True)
     step_path = output / f"{name}.step"
     stl_path = output / f"{name}.stl"
@@ -179,6 +252,7 @@ def export_part(
             if intent and intent.is_file()
             else None
         ),
+        "parameters": dict(_PARAMETERS),
         "part": name,
         "schema": "evidence-cad-build/v2",
         "shape": stats,

--- a/src/components/CadWorkbench.tsx
+++ b/src/components/CadWorkbench.tsx
@@ -32,8 +32,10 @@ import {
   fetchArtifactArchive,
   fetchArtifacts,
   fetchHealth,
+  fetchModelParameters,
   fetchSessionCatalog,
   fetchSessionDetail,
+  rebuildModelParameters,
   streamAgent,
   trashArtifacts,
 } from '../lib/agent-api';
@@ -51,6 +53,7 @@ import {
   type ArtifactWorkspace,
   type ChatMessage,
   type HealthResponse,
+  type ParameterModel,
   type SessionSummary,
 } from '../types';
 
@@ -81,6 +84,12 @@ export function CadWorkbench({
     const [leftView, setLeftView] = useState<LeftView>('chat');
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
+    const [parameterBuilding, setParameterBuilding] = useState(false);
+    const [parameterIssue, setParameterIssue] = useState<string>();
+    const [parameterModels, setParameterModels] = useState<ParameterModel[]>([]);
+    const [parameterValues, setParameterValues] = useState<
+      Record<string, number>
+    >({});
     const [prompt, setPrompt] = useState('');
     const [running, setRunning] = useState(false);
     const [runtimeEntries, setRuntimeEntries] = useState<RuntimeEntry[]>([]);
@@ -95,6 +104,7 @@ export function CadWorkbench({
     const abortRef = useRef<AbortController | undefined>(undefined);
     const artifactSnapshotRef = useRef<ArtifactSummary[]>([]);
     const conversationRef = useRef<HTMLElement>(null);
+    const parameterBuildingRef = useRef(false);
     const sessionMenuRef = useDismissibleLayer<HTMLDivElement>({
       onDismiss: () => setSessionMenuOpen(false),
       open: sessionMenuOpen,
@@ -134,6 +144,15 @@ export function CadWorkbench({
       sessionId === BUNDLED_POMODORO_SESSION_ID
         ? text('Amagine3D Pomodoro Timer', 'Amagine3D 番茄钟')
         : sessionTitle(activeSession);
+    const activeParameterModel = useMemo(
+      () =>
+        selectedArtifact?.kind === 'model'
+          ? parameterModels.find(
+              (model) => model.primaryPreviewPath === selectedArtifact.path,
+            )
+          : undefined,
+      [parameterModels, selectedArtifact],
+    );
 
     function addRuntimeEntry(
       message: string,
@@ -238,7 +257,7 @@ export function CadWorkbench({
     }
 
     async function openSession(target: SessionSummary) {
-      if (running || sessionLoading || target.id === sessionId) {
+      if (running || parameterBuilding || sessionLoading || target.id === sessionId) {
         setSessionMenuOpen(false);
         return;
       }
@@ -254,15 +273,22 @@ export function CadWorkbench({
           setMessages([]);
           setArtifacts([]);
           setArtifactWorkspace(draftWorkspace(target.id));
+          setParameterModels([]);
+          setParameterIssue(undefined);
           setSelectedPath(undefined);
           setSelectedText(undefined);
           return;
         }
-        const detail = await fetchSessionDetail(target.id);
+        const [detail, parameterCollection] = await Promise.all([
+          fetchSessionDetail(target.id),
+          fetchModelParameters(target.id),
+        ]);
         setSessionId(detail.session.id);
         setMessages(detail.messages);
         setArtifacts(detail.artifacts);
         setArtifactWorkspace(detail.artifactWorkspace);
+        setParameterModels(parameterCollection.models);
+        setParameterIssue(undefined);
         selectInitialArtifact(detail.artifacts);
       } catch (error) {
         addRuntimeEntry(errorText(error, language), 'session', 'error');
@@ -274,9 +300,13 @@ export function CadWorkbench({
     async function refreshArtifacts() {
       setStorageLoading(true);
       try {
-        const next = await fetchArtifacts(sessionId);
+        const [next, parameterCollection] = await Promise.all([
+          fetchArtifacts(sessionId),
+          fetchModelParameters(sessionId),
+        ]);
         setArtifacts(next.artifacts);
         setArtifactWorkspace(next.artifactWorkspace);
+        setParameterModels(parameterCollection.models);
         setSelectedPath((current) => {
           if (
             current &&
@@ -293,6 +323,20 @@ export function CadWorkbench({
         setStorageLoading(false);
       }
     }
+
+    useEffect(() => {
+      setParameterIssue(undefined);
+      setParameterValues(
+        activeParameterModel
+          ? Object.fromEntries(
+              activeParameterModel.parameters.map((parameter) => [
+                parameter.id,
+                parameter.value,
+              ]),
+            )
+          : {},
+      );
+    }, [activeParameterModel]);
 
     useEffect(() => {
       let live = true;
@@ -323,12 +367,16 @@ export function CadWorkbench({
         .then(async (catalog) => {
           if (!live) return;
           setSessions(catalog.sessions);
-          const detail = await fetchSessionDetail(catalog.initialSessionId);
+          const [detail, parameterCollection] = await Promise.all([
+            fetchSessionDetail(catalog.initialSessionId),
+            fetchModelParameters(catalog.initialSessionId),
+          ]);
           if (!live) return;
           setSessionId(detail.session.id);
           setMessages(detail.messages);
           setArtifacts(detail.artifacts);
           setArtifactWorkspace(detail.artifactWorkspace);
+          setParameterModels(parameterCollection.models);
           selectInitialArtifact(detail.artifacts);
         })
         .catch((error: unknown) => {
@@ -456,6 +504,11 @@ export function CadWorkbench({
           preferredPreviewArtifact(changedArtifacts) ??
           preferredPreviewArtifact(event.artifacts);
         if (currentPreview) setSelectedPath(currentPreview.path);
+        void fetchModelParameters(event.sessionId)
+          .then((collection) => setParameterModels(collection.models))
+          .catch((error: unknown) => {
+            setParameterIssue(errorText(error, language));
+          });
         addRuntimeEntry(
           text(
             `${String(event.artifacts.length)} workspace files discovered`,
@@ -476,12 +529,68 @@ export function CadWorkbench({
       if (event.type === 'error') throw new Error(event.message);
     }
 
+    async function commitParameter(parameterId: string) {
+      const model = activeParameterModel;
+      const parameter = model?.parameters.find(({ id }) => id === parameterId);
+      const value = parameterValues[parameterId];
+      if (
+        !model ||
+        !parameter ||
+        value === undefined ||
+        value === parameter.value ||
+        parameterBuildingRef.current ||
+        running ||
+        artifactWorkspace.readOnly
+      ) {
+        return;
+      }
+      parameterBuildingRef.current = true;
+      setParameterBuilding(true);
+      setParameterIssue(undefined);
+      const parameterLabel =
+        language === 'zh' && parameter.labelZh?.trim()
+          ? parameter.labelZh.trim()
+          : parameter.label;
+      addRuntimeEntry(
+        text(
+          `Rebuilding complete model with ${parameterLabel}=${String(value)}`,
+          `正在以 ${parameterLabel}=${String(value)} 重建完整模型`,
+        ),
+        'parameters',
+      );
+      try {
+        const next = await rebuildModelParameters(sessionId, model, {
+          [parameterId]: value,
+        });
+        setArtifacts(next.artifacts);
+        setArtifactWorkspace(next.artifactWorkspace);
+        setParameterModels(next.models);
+        setSelectedPath(model.primaryPreviewPath);
+        addRuntimeEntry(
+          text('Complete model rebuilt', '完整模型已重建'),
+          'parameters',
+        );
+      } catch (error) {
+        setParameterIssue(errorText(error, language));
+        setParameterValues(
+          Object.fromEntries(
+            model.parameters.map((item) => [item.id, item.value]),
+          ),
+        );
+        addRuntimeEntry(errorText(error, language), 'parameters', 'error');
+      } finally {
+        parameterBuildingRef.current = false;
+        setParameterBuilding(false);
+      }
+    }
+
     async function submit(event?: FormEvent) {
       event?.preventDefault();
       const messageText = prompt.trim();
       if (
         (!messageText && pendingImages.length === 0) ||
         running ||
+        parameterBuilding ||
         sessionLoading
       ) {
         return;
@@ -642,6 +751,8 @@ export function CadWorkbench({
       setMessages([]);
       setArtifacts([]);
       setArtifactWorkspace(draftWorkspace(nextSessionId));
+      setParameterModels([]);
+      setParameterIssue(undefined);
       setSelectedPath(undefined);
       setSelectedText(undefined);
       if (!preserveComposer) {
@@ -655,7 +766,7 @@ export function CadWorkbench({
     }
 
     function beginFreshRun() {
-      if (running || sessionLoading) return;
+      if (running || parameterBuilding || sessionLoading) return;
       beginUserDraft();
     }
 
@@ -664,6 +775,7 @@ export function CadWorkbench({
         <LeftPanel
           chat={{
             activity,
+            busy: parameterBuilding,
             conversationRef,
             language,
             messages,
@@ -707,7 +819,7 @@ export function CadWorkbench({
           }
           onToggleMenu={() => setSessionMenuOpen((open) => !open)}
           onViewChange={setLeftView}
-          running={running}
+          running={running || parameterBuilding}
           sessionId={sessionId}
           sessionLoading={sessionLoading}
           sessionMenuRef={sessionMenuRef}
@@ -735,7 +847,7 @@ export function CadWorkbench({
           onLogResize={beginLogResize}
           onToggleLog={() => setLogCollapsed((collapsed) => !collapsed)}
           previewArtifact={previewArtifact}
-          running={running}
+          running={running || parameterBuilding}
           runtimeEntries={runtimeEntries}
           runtimeReady={Boolean(health?.runtimeReady)}
           selectedArtifact={selectedArtifact}
@@ -753,9 +865,22 @@ export function CadWorkbench({
         </div>
 
         <ParametersPanel
+          busy={parameterBuilding || running}
           collapsed={rightCollapsed}
+          hasParameterModels={parameterModels.length > 0}
+          issue={parameterIssue}
           language={language}
+          model={activeParameterModel}
+          onCommit={(parameterId) => void commitParameter(parameterId)}
           onToggle={() => setRightCollapsed((collapsed) => !collapsed)}
+          onValueChange={(parameterId, value) =>
+            setParameterValues((current) => ({
+              ...current,
+              [parameterId]: value,
+            }))
+          }
+          rebuilding={parameterBuilding}
+          values={parameterValues}
         />
         {storageOpen ? (
           <StorageDrawer

--- a/src/components/cad-workbench/ChatPanel.tsx
+++ b/src/components/cad-workbench/ChatPanel.tsx
@@ -17,6 +17,7 @@ import { LoadingSpinner, ToolbarIcon } from './WorkbenchPrimitives';
 
 export interface ChatPanelProps {
   activity: string;
+  busy: boolean;
   conversationRef: RefObject<HTMLElement | null>;
   language: Language;
   messages: ChatMessage[];
@@ -39,6 +40,7 @@ export interface ChatPanelProps {
 
 export function ChatPanel({
   activity,
+  busy,
   conversationRef,
   language,
   messages,
@@ -123,9 +125,9 @@ export function ChatPanel({
         <form className={composerStyles.composerForm} onSubmit={onSubmit}>
           <div className={composerStyles.composerShell}>
             <textarea
-              aria-busy={running}
+              aria-busy={running || busy}
               aria-label={text('CAD request', 'CAD 请求')}
-              disabled={running || sessionLoading}
+              disabled={running || busy || sessionLoading}
               maxLength={8_000}
               onChange={(event) => onPromptChange(event.target.value)}
               onKeyDown={onKeyDown}
@@ -161,7 +163,7 @@ export function ChatPanel({
                   aria-label={text('New project', '新项目')}
                   className={composerStyles.composerTool}
                   data-tooltip={text('New project', '新项目')}
-                  disabled={running || sessionLoading}
+                  disabled={running || busy || sessionLoading}
                   onClick={onNewProject}
                   type="button"
                 >
@@ -180,7 +182,7 @@ export function ChatPanel({
                   <input
                     accept={ACCEPTED_IMAGE_TYPES.join(',')}
                     className={composerStyles.srOnly}
-                    disabled={running || sessionLoading}
+                    disabled={running || busy || sessionLoading}
                     multiple
                     onChange={onSelectImages}
                     type="file"
@@ -211,7 +213,7 @@ export function ChatPanel({
                         )
                   }
                   disabled={
-                    running || sessionLoading || !webSearchConfigured
+                    running || busy || sessionLoading || !webSearchConfigured
                   }
                   onClick={() =>
                     onWebSearchEnabledChange(!webSearchEnabled)
@@ -232,7 +234,8 @@ export function ChatPanel({
                 data-state={running ? 'stop' : 'send'}
                 disabled={
                   !running &&
-                  (sessionLoading ||
+                  (busy ||
+                    sessionLoading ||
                     (!prompt.trim() && pendingImages.length === 0))
                 }
                 onClick={running ? onStop : undefined}

--- a/src/components/cad-workbench/ParametersPanel.module.css
+++ b/src/components/cad-workbench/ParametersPanel.module.css
@@ -90,6 +90,100 @@
   margin-block-start: var(--space-xl);
 }
 
+.parameterIssue {
+  padding: var(--space-sm);
+  border: var(--rule-thin) solid color-mix(in srgb, var(--color-error) 38%, transparent);
+  border-radius: var(--radius-sm);
+  margin-block-end: var(--space-md);
+  background: color-mix(in srgb, var(--color-error) 8%, transparent);
+  color: var(--color-error);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
+.parameterGroup {
+  display: grid;
+  padding: 0;
+  border: 0;
+  margin: 0;
+  gap: var(--space-md);
+}
+
+.parameterGroup legend {
+  width: 100%;
+  padding: 0 0 var(--space-xs);
+  border-block-end: var(--rule-thin) solid var(--color-rule);
+  margin-block-end: var(--space-sm);
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+}
+
+.parameterField {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.parameterField > label {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.parameterField code {
+  overflow: hidden;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  text-overflow: ellipsis;
+}
+
+.parameterValueRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.parameterValueRow input {
+  width: 100%;
+  min-width: 0;
+  padding: 0.45rem 0.55rem;
+  border: var(--rule-thin) solid var(--color-rule-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font: inherit;
+  font-family: var(--font-mono);
+}
+
+.parameterValueRow span,
+.parameterBounds,
+.parameterAffects {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.parameterAffects {
+  overflow-wrap: anywhere;
+}
+
+.parameterField input[type='range'] {
+  width: 100%;
+  accent-color: var(--color-accent);
+}
+
+.parameterGroup:disabled {
+  opacity: 0.62;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .panelCollapseButton:not(:disabled):hover {
     background: var(--color-fill);

--- a/src/components/cad-workbench/ParametersPanel.module.css
+++ b/src/components/cad-workbench/ParametersPanel.module.css
@@ -101,23 +101,28 @@
   line-height: 1.5;
 }
 
+.parameterGroups {
+  display: grid;
+  gap: var(--space-lg);
+}
+
 .parameterGroup {
   display: grid;
-  padding: 0;
-  border: 0;
+  padding: var(--space-md);
+  border: var(--rule-thin) solid var(--color-rule);
+  border-radius: var(--radius-sm);
   margin: 0;
+  background: color-mix(in srgb, var(--color-fill) 38%, transparent);
   gap: var(--space-md);
 }
 
 .parameterGroup legend {
-  width: 100%;
-  padding: 0 0 var(--space-xs);
-  border-block-end: var(--rule-thin) solid var(--color-rule);
-  margin-block-end: var(--space-sm);
-  color: var(--color-muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
+  width: auto;
+  padding: 0 var(--space-xs);
+  color: var(--color-ink-soft);
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 600;
 }
 
 .parameterField {
@@ -164,7 +169,7 @@
 }
 
 .parameterValueRow span,
-.parameterBounds,
+.parameterLimits,
 .parameterAffects {
   color: var(--color-muted);
   font-family: var(--font-mono);
@@ -175,9 +180,30 @@
   overflow-wrap: anywhere;
 }
 
-.parameterField input[type='range'] {
+.parameterRange {
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.parameterRange input[type='range'] {
   width: 100%;
   accent-color: var(--color-accent);
+}
+
+.parameterLimits {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.parameterLimits span:last-child {
+  text-align: end;
+}
+
+.parameterLimits b {
+  color: var(--color-ink-soft);
+  font-size: 0.625rem;
+  letter-spacing: 0.06em;
 }
 
 .parameterGroup:disabled {

--- a/src/components/cad-workbench/ParametersPanel.module.css
+++ b/src/components/cad-workbench/ParametersPanel.module.css
@@ -121,7 +121,7 @@
   padding: 0 var(--space-xs);
   color: var(--color-ink-soft);
   font-family: var(--font-display);
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   font-weight: 600;
 }
 

--- a/src/components/cad-workbench/ParametersPanel.tsx
+++ b/src/components/cad-workbench/ParametersPanel.tsx
@@ -4,12 +4,38 @@ import type { ParameterModel } from '../../types';
 import type { Language } from './types';
 import { translator } from './types';
 
+interface ParameterGroup {
+  id: string;
+  label: string;
+  parameters: ParameterModel['parameters'];
+}
+
 function localizedText(
   language: Language,
   english: string,
   chinese?: string,
 ): string {
   return language === 'zh' && chinese?.trim() ? chinese.trim() : english;
+}
+
+function groupedParameters(
+  model: ParameterModel,
+  language: Language,
+): ParameterGroup[] {
+  const groups = new Map<string, ParameterGroup>();
+  for (const parameter of model.parameters) {
+    const english = parameter.group?.trim();
+    const chinese = parameter.groupZh?.trim();
+    const id = english || chinese || '__general__';
+    const label =
+      language === 'zh'
+        ? chinese || english || '常规'
+        : english || chinese || 'General';
+    const group = groups.get(id);
+    if (group) group.parameters.push(parameter);
+    else groups.set(id, { id, label, parameters: [parameter] });
+  }
+  return [...groups.values()];
 }
 
 interface ParametersPanelProps {
@@ -40,6 +66,7 @@ export function ParametersPanel({
   values,
 }: ParametersPanelProps) {
   const text = translator(language);
+  const parameterGroups = model ? groupedParameters(model, language) : [];
   return (
     <aside
       aria-label={text('Model parameters', '模型参数')}
@@ -103,81 +130,91 @@ export function ParametersPanel({
               title={text('No declared parameters.', '没有已声明的参数。')}
             />
           ) : (
-            <fieldset className={styles.parameterGroup} disabled={busy}>
-              <legend>{text('Complete model', '完整模型')}</legend>
-              {model.parameters.map((parameter) => {
-                const label = localizedText(
-                  language,
-                  parameter.label,
-                  parameter.labelZh,
-                );
-                const group = parameter.group
-                  ? localizedText(
+            <div className={styles.parameterGroups}>
+              {parameterGroups.map((group) => (
+                <fieldset
+                  className={styles.parameterGroup}
+                  disabled={busy}
+                  key={group.id}
+                >
+                  <legend>{group.label}</legend>
+                  {group.parameters.map((parameter) => {
+                    const label = localizedText(
                       language,
-                      parameter.group,
-                      parameter.groupZh,
-                    )
-                  : language === 'zh'
-                    ? parameter.groupZh
-                    : undefined;
-                const value = values[parameter.id] ?? parameter.value;
-                return (
-                  <div className={styles.parameterField} key={parameter.id}>
-                    <label htmlFor={`parameter-${parameter.id}`}>
-                      <span>{label}</span>
-                      <code>{parameter.name}</code>
-                    </label>
-                    <div className={styles.parameterValueRow}>
-                      <input
-                        id={`parameter-${parameter.id}`}
-                        max={parameter.maximum}
-                        min={parameter.minimum}
-                        onBlur={() => onCommit(parameter.id)}
-                        onChange={(event) => {
-                          const next = event.currentTarget.valueAsNumber;
-                          if (Number.isFinite(next)) {
-                            onValueChange(parameter.id, next);
-                          }
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter') event.currentTarget.blur();
-                        }}
-                        step={parameter.step}
-                        type="number"
-                        value={value}
-                      />
-                      {parameter.unit ? <span>{parameter.unit}</span> : null}
-                    </div>
-                    <input
-                      aria-label={label}
-                      max={parameter.maximum}
-                      min={parameter.minimum}
-                      onChange={(event) =>
-                        onValueChange(
-                          parameter.id,
-                          event.currentTarget.valueAsNumber,
-                        )
-                      }
-                      onKeyUp={() => onCommit(parameter.id)}
-                      onPointerUp={() => onCommit(parameter.id)}
-                      step={parameter.step}
-                      type="range"
-                      value={value}
-                    />
-                    <small className={styles.parameterBounds}>
-                      {parameter.minimum}–{parameter.maximum}
-                      {group ? ` · ${group}` : ''}
-                    </small>
-                    {parameter.affects.length > 0 ? (
-                      <small className={styles.parameterAffects}>
-                        {text('Affects', '影响')}:{' '}
-                        {parameter.affects.join(', ')}
-                      </small>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </fieldset>
+                      parameter.label,
+                      parameter.labelZh,
+                    );
+                    const value = values[parameter.id] ?? parameter.value;
+                    const unit = parameter.unit ? ` ${parameter.unit}` : '';
+                    return (
+                      <div className={styles.parameterField} key={parameter.id}>
+                        <label htmlFor={`parameter-${parameter.id}`}>
+                          <span>{label}</span>
+                          <code>{parameter.name}</code>
+                        </label>
+                        <div className={styles.parameterValueRow}>
+                          <input
+                            id={`parameter-${parameter.id}`}
+                            max={parameter.maximum}
+                            min={parameter.minimum}
+                            onBlur={() => onCommit(parameter.id)}
+                            onChange={(event) => {
+                              const next = event.currentTarget.valueAsNumber;
+                              if (Number.isFinite(next)) {
+                                onValueChange(parameter.id, next);
+                              }
+                            }}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') {
+                                event.currentTarget.blur();
+                              }
+                            }}
+                            step={parameter.step}
+                            type="number"
+                            value={value}
+                          />
+                          {parameter.unit ? <span>{parameter.unit}</span> : null}
+                        </div>
+                        <div className={styles.parameterRange}>
+                          <input
+                            aria-label={label}
+                            max={parameter.maximum}
+                            min={parameter.minimum}
+                            onChange={(event) =>
+                              onValueChange(
+                                parameter.id,
+                                event.currentTarget.valueAsNumber,
+                              )
+                            }
+                            onKeyUp={() => onCommit(parameter.id)}
+                            onPointerUp={() => onCommit(parameter.id)}
+                            step={parameter.step}
+                            type="range"
+                            value={value}
+                          />
+                          <small className={styles.parameterLimits}>
+                            <span>
+                              <b>MIN</b> {parameter.minimum}
+                              {unit}
+                            </span>
+                            <span>
+                              <b>MAX</b> {parameter.maximum}
+                              {unit}
+                            </span>
+                          </small>
+                        </div>
+                        {parameter.affects.length > 0 ? (
+                          <small className={styles.parameterAffects}>
+                            {text('Affects', '影响')}:{' '}
+                            {parameter.affects.join(', ')}
+                          </small>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </fieldset>
+              ))}
+            </div>
           )}
         </div>
       )}

--- a/src/components/cad-workbench/ParametersPanel.tsx
+++ b/src/components/cad-workbench/ParametersPanel.tsx
@@ -1,18 +1,43 @@
 import styles from './ParametersPanel.module.css';
 import { EmptyState } from '../ui/EmptyState';
+import type { ParameterModel } from '../../types';
 import type { Language } from './types';
 import { translator } from './types';
 
+function localizedText(
+  language: Language,
+  english: string,
+  chinese?: string,
+): string {
+  return language === 'zh' && chinese?.trim() ? chinese.trim() : english;
+}
+
 interface ParametersPanelProps {
+  busy: boolean;
   collapsed: boolean;
+  hasParameterModels: boolean;
+  issue?: string;
   language: Language;
+  model?: ParameterModel;
+  onCommit: (parameterId: string) => void;
   onToggle: () => void;
+  onValueChange: (parameterId: string, value: number) => void;
+  rebuilding: boolean;
+  values: Record<string, number>;
 }
 
 export function ParametersPanel({
+  busy,
   collapsed,
+  hasParameterModels,
+  issue,
   language,
+  model,
+  onCommit,
   onToggle,
+  onValueChange,
+  rebuilding,
+  values,
 }: ParametersPanelProps) {
   const text = translator(language);
   return (
@@ -33,20 +58,127 @@ export function ParametersPanel({
           </button>
           <div>
             <strong>{text('Parameters', '参数')}</strong>
-            <small>{text('Agent-produced project', 'Agent 生成项目')}</small>
+            <small>
+              {rebuilding
+                ? text('Rebuilding complete model…', '正在重建完整模型…')
+                : model
+                  ? model.modelId
+                  : text('Complete model controls', '完整模型控制')}
+            </small>
           </div>
         </div>
       </header>
       {collapsed ? null : (
         <div className={styles.parameterScroll}>
-          <EmptyState
-            className={styles.emptyState}
-            description={text(
-              'Adjustable model parameters will appear here when the project provides them.',
-              '项目提供可调模型参数后，它们会显示在这里。',
-            )}
-            title={text('No adjustable parameters yet.', '暂时没有可调参数。')}
-          />
+          {issue ? <div className={styles.parameterIssue}>{issue}</div> : null}
+          {!model ? (
+            <EmptyState
+              className={styles.emptyState}
+              description={
+                hasParameterModels
+                  ? text(
+                      'Select the combined STL or top-level 3MF to adjust the complete model.',
+                      '请选择组合 STL 或顶层 3MF，才能调整完整模型。',
+                    )
+                  : text(
+                      'Adjustable model parameters will appear here when the project declares them.',
+                      '项目声明可调模型参数后，它们会显示在这里。',
+                    )
+              }
+              title={
+                hasParameterModels
+                  ? text('Open the complete model.', '请打开完整模型。')
+                  : text('No adjustable parameters yet.', '暂时没有可调参数。')
+              }
+            />
+          ) : model.parameterError ? (
+            <div className={styles.parameterIssue}>{model.parameterError}</div>
+          ) : model.parameters.length === 0 ? (
+            <EmptyState
+              className={styles.emptyState}
+              description={text(
+                'This complete model does not declare any parameter() controls.',
+                '这个完整模型尚未声明任何 parameter() 控件。',
+              )}
+              title={text('No declared parameters.', '没有已声明的参数。')}
+            />
+          ) : (
+            <fieldset className={styles.parameterGroup} disabled={busy}>
+              <legend>{text('Complete model', '完整模型')}</legend>
+              {model.parameters.map((parameter) => {
+                const label = localizedText(
+                  language,
+                  parameter.label,
+                  parameter.labelZh,
+                );
+                const group = parameter.group
+                  ? localizedText(
+                      language,
+                      parameter.group,
+                      parameter.groupZh,
+                    )
+                  : language === 'zh'
+                    ? parameter.groupZh
+                    : undefined;
+                const value = values[parameter.id] ?? parameter.value;
+                return (
+                  <div className={styles.parameterField} key={parameter.id}>
+                    <label htmlFor={`parameter-${parameter.id}`}>
+                      <span>{label}</span>
+                      <code>{parameter.name}</code>
+                    </label>
+                    <div className={styles.parameterValueRow}>
+                      <input
+                        id={`parameter-${parameter.id}`}
+                        max={parameter.maximum}
+                        min={parameter.minimum}
+                        onBlur={() => onCommit(parameter.id)}
+                        onChange={(event) => {
+                          const next = event.currentTarget.valueAsNumber;
+                          if (Number.isFinite(next)) {
+                            onValueChange(parameter.id, next);
+                          }
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') event.currentTarget.blur();
+                        }}
+                        step={parameter.step}
+                        type="number"
+                        value={value}
+                      />
+                      {parameter.unit ? <span>{parameter.unit}</span> : null}
+                    </div>
+                    <input
+                      aria-label={label}
+                      max={parameter.maximum}
+                      min={parameter.minimum}
+                      onChange={(event) =>
+                        onValueChange(
+                          parameter.id,
+                          event.currentTarget.valueAsNumber,
+                        )
+                      }
+                      onKeyUp={() => onCommit(parameter.id)}
+                      onPointerUp={() => onCommit(parameter.id)}
+                      step={parameter.step}
+                      type="range"
+                      value={value}
+                    />
+                    <small className={styles.parameterBounds}>
+                      {parameter.minimum}–{parameter.maximum}
+                      {group ? ` · ${group}` : ''}
+                    </small>
+                    {parameter.affects.length > 0 ? (
+                      <small className={styles.parameterAffects}>
+                        {text('Affects', '影响')}:{' '}
+                        {parameter.affects.join(', ')}
+                      </small>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </fieldset>
+          )}
         </div>
       )}
     </aside>

--- a/src/lib/agent-api.ts
+++ b/src/lib/agent-api.ts
@@ -3,6 +3,9 @@ import type {
   ArtifactCollection,
   HealthResponse,
   ImageAttachment,
+  ParameterBuildResult,
+  ParameterCollection,
+  ParameterModel,
   SessionCatalog,
   SessionDetail,
 } from '../types';
@@ -42,6 +45,43 @@ export async function fetchArtifacts(
   );
   if (!response.ok) throw new Error('无法读取工作区文件。');
   return (await response.json()) as ArtifactCollection;
+}
+
+export async function fetchModelParameters(
+  sessionId: string,
+): Promise<ParameterCollection> {
+  const response = await fetch(
+    `/api/sessions/${encodeURIComponent(sessionId)}/parameters`,
+  );
+  if (!response.ok) throw new Error('无法读取模型参数。');
+  return (await response.json()) as ParameterCollection;
+}
+
+export async function rebuildModelParameters(
+  sessionId: string,
+  model: ParameterModel,
+  values: Record<string, number>,
+): Promise<ParameterBuildResult> {
+  const response = await fetch(
+    `/api/sessions/${encodeURIComponent(sessionId)}/parameters/rebuild`,
+    {
+      body: JSON.stringify({
+        primaryPreviewPath: model.primaryPreviewPath,
+        sourceHash: model.sourceHash,
+        sourcePath: model.sourcePath,
+        values,
+      }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    },
+  );
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    throw new Error(body.message || '参数化重建失败。');
+  }
+  return (await response.json()) as ParameterBuildResult;
 }
 
 export async function fetchArtifactArchive(

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,42 @@ export interface ArtifactCollection {
   artifactWorkspace: ArtifactWorkspace;
 }
 
+export interface ModelParameter {
+  affects: string[];
+  defaultValue: number;
+  group?: string;
+  groupZh?: string;
+  id: string;
+  kind: 'integer' | 'number';
+  label: string;
+  labelZh?: string;
+  maximum: number;
+  minimum: number;
+  name: string;
+  step: number;
+  unit?: string;
+  value: number;
+}
+
+export interface ParameterModel {
+  artifactPaths: string[];
+  modelId: string;
+  parameterError?: string;
+  parameters: ModelParameter[];
+  primaryPreviewPath: string;
+  reportPath: string;
+  sourceHash: string;
+  sourcePath: string;
+}
+
+export interface ParameterCollection {
+  models: ParameterModel[];
+}
+
+export interface ParameterBuildResult
+  extends ArtifactCollection,
+    ParameterCollection {}
+
 export type SessionKind = 'builtin' | 'user';
 
 export interface SessionSummary {

--- a/tests/model-parameters.test.ts
+++ b/tests/model-parameters.test.ts
@@ -1,0 +1,330 @@
+import { strict as assert } from 'node:assert';
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { test } from 'node:test';
+import { promisify } from 'node:util';
+
+import {
+  parameterModelsForWorkspace,
+  parseParameterBuildRequest,
+  rebuildModelWithParameters,
+} from '../server/model-parameters.ts';
+
+const PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+const PROJECT_ROOT = resolve(import.meta.dirname, '..');
+const VENV_PYTHON =
+  process.platform === 'win32'
+    ? join(PROJECT_ROOT, '.venv', 'Scripts', 'python.exe')
+    : join(PROJECT_ROOT, '.venv', 'bin', 'python');
+const execFileAsync = promisify(execFile);
+
+function modelSource(): string {
+  return `import hashlib
+import json
+import os
+from pathlib import Path
+
+def parameter(parameter_id, default, **metadata):
+    overrides = json.loads(os.environ.get("AMAGINE3D_PARAMETER_OVERRIDES", "{}"))
+    return overrides.get(parameter_id, default)
+
+NAME = "model"
+SIZE = parameter(
+    "local-offset",
+    -2.5,
+    min_value=-5.0,
+    max_value=5.0,
+    step=0.5,
+    unit="mm",
+    label="Local offset",
+    label_zh="局部偏移",
+    group="Feature",
+    group_zh="局部特征",
+    affects=("mounting-hole",),
+)
+
+if SIZE > 3:
+    raise RuntimeError("simulated topology failure")
+
+output = Path(os.environ.get("AMAGINE3D_OUTPUT_DIR", "."))
+output.mkdir(parents=True, exist_ok=True)
+stl = output / "model.stl"
+step = output / "model.step"
+stl.write_text(f"solid {SIZE}\\nendsolid model\\n", encoding="utf-8")
+step.write_text(f"STEP {SIZE}\\n", encoding="utf-8")
+digest = lambda path: hashlib.sha256(path.read_bytes()).hexdigest()
+report = {
+    "schema": "evidence-cad-build/v2",
+    "part": NAME,
+    "source": {"path": str(Path(__file__).resolve()), "sha256": digest(Path(__file__))},
+    "artifacts": {
+        "stl": {"path": str(stl.resolve()), "sha256": digest(stl)},
+        "step": {"path": str(step.resolve()), "sha256": digest(step)},
+    },
+    "parameters": {
+        "local-offset": {"default": -2.5, "value": SIZE},
+    },
+}
+(output / "model_report.json").write_text(json.dumps(report), encoding="utf-8")
+print(json.dumps(report))
+`;
+}
+
+async function writeInitialBuild(root: string): Promise<void> {
+  const sourcePath = join(root, 'model.py');
+  const stlPath = join(root, 'model.stl');
+  const stepPath = join(root, 'model.step');
+  await writeFile(sourcePath, modelSource());
+  await writeFile(stlPath, 'solid -2.5\nendsolid model\n');
+  await writeFile(stepPath, 'STEP -2.5\n');
+  await writeFile(
+    join(root, 'model_report.json'),
+    JSON.stringify({
+      artifacts: {
+        step: { path: stepPath, sha256: 'initial' },
+        stl: { path: stlPath, sha256: 'initial' },
+      },
+      part: 'model',
+      schema: 'evidence-cad-build/v2',
+      source: { path: sourcePath, sha256: 'initial' },
+    }),
+  );
+}
+
+test('discovers only explicit parameter() declarations, including negative defaults', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'amagine-parameters-'));
+  try {
+    await writeInitialBuild(root);
+    const [model] = await parameterModelsForWorkspace(root, PYTHON);
+    assert.equal(model?.primaryPreviewPath, 'model.stl');
+    assert.equal(model?.parameters.length, 1);
+    assert.deepEqual(model?.parameters[0], {
+      affects: ['mounting-hole'],
+      defaultValue: -2.5,
+      group: 'Feature',
+      groupZh: '局部特征',
+      id: 'local-offset',
+      kind: 'number',
+      label: 'Local offset',
+      labelZh: '局部偏移',
+      maximum: 5,
+      minimum: -5,
+      name: 'SIZE',
+      step: 0.5,
+      unit: 'mm',
+      value: -2.5,
+    });
+
+    await writeFile(
+      join(root, 'model.py'),
+      modelSource().replace('label_zh="局部偏移"', 'label_zh=42'),
+    );
+    const [fallbackModel] = await parameterModelsForWorkspace(root, PYTHON);
+    assert.equal(fallbackModel?.parameterError, undefined);
+    assert.equal(fallbackModel?.parameters[0]?.label, 'Local offset');
+    assert.equal(fallbackModel?.parameters[0]?.labelZh, undefined);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test('rebuilds the complete model in staging and commits source only after success', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'amagine-parameter-build-'));
+  try {
+    await writeInitialBuild(root);
+    const [model] = await parameterModelsForWorkspace(root, PYTHON);
+    assert.ok(model);
+    await rebuildModelWithParameters({
+      pythonExecutable: PYTHON,
+      request: {
+        primaryPreviewPath: model.primaryPreviewPath,
+        sourceHash: model.sourceHash,
+        sourcePath: model.sourcePath,
+        values: { 'local-offset': -1.5 },
+      },
+      workspaceRoot: root,
+    });
+    assert.match(await readFile(join(root, 'model.py'), 'utf8'), /\n\s+-1\.5,/u);
+    assert.match(await readFile(join(root, 'model.stl'), 'utf8'), /-1\.5/u);
+    const report = JSON.parse(
+      await readFile(join(root, 'model_report.json'), 'utf8'),
+    ) as { source: { path: string; sha256: string } };
+    assert.equal(report.source.path, join(root, 'model.py'));
+    assert.match(report.source.sha256, /^[a-f0-9]{64}$/u);
+
+    const committedSource = await readFile(join(root, 'model.py'), 'utf8');
+    const committedStl = await readFile(join(root, 'model.stl'), 'utf8');
+    const [committedModel] = await parameterModelsForWorkspace(root, PYTHON);
+    assert.ok(committedModel);
+    await assert.rejects(
+      rebuildModelWithParameters({
+        pythonExecutable: PYTHON,
+        request: {
+          primaryPreviewPath: committedModel.primaryPreviewPath,
+          sourceHash: committedModel.sourceHash,
+          sourcePath: committedModel.sourcePath,
+          values: { 'local-offset': 4 },
+        },
+        workspaceRoot: root,
+      }),
+      /simulated topology failure/u,
+    );
+    assert.equal(await readFile(join(root, 'model.py'), 'utf8'), committedSource);
+    assert.equal(await readFile(join(root, 'model.stl'), 'utf8'), committedStl);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test('rejects malformed parameter build requests', () => {
+  assert.equal(parseParameterBuildRequest({ values: {} }), undefined);
+  assert.equal(
+    parseParameterBuildRequest({
+      primaryPreviewPath: 'model.stl',
+      sourceHash: 'a'.repeat(64),
+      sourcePath: 'model.py',
+      values: { size: Number.NaN },
+    }),
+    undefined,
+  );
+});
+
+test(
+  'rebuilds a real build123d model through the checked helper runtime',
+  { skip: !existsSync(VENV_PYTHON) },
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), 'amagine-build123d-parameter-'));
+    try {
+      const skillRoot = join(PROJECT_ROOT, 'skills', 'text-a3d');
+      const source = `import sys
+sys.path.insert(0, ${JSON.stringify(skillRoot)})
+from build123d import Box
+from cad_helpers import export_part, observe, parameter
+
+NAME = "parametric_box"
+WIDTH = parameter(
+    "overall-width", 20.0,
+    min_value=10.0, max_value=30.0, step=0.5,
+    unit="mm", label="Overall width", label_zh="总体宽度",
+    group="Envelope", group_zh="外形尺寸",
+    affects=("primary-envelope",),
+)
+DEPTH = 12.0
+HEIGHT = 6.0
+body = Box(WIDTH, DEPTH, HEIGHT)
+observe(body, "primary-envelope", "envelope")
+
+if __name__ == "__main__":
+    export_part(body, NAME, source_path=__file__)
+`;
+      await writeFile(join(root, 'parametric_box.py'), source);
+      await execFileAsync(VENV_PYTHON, ['parametric_box.py'], { cwd: root });
+      const [model] = await parameterModelsForWorkspace(root, VENV_PYTHON);
+      assert.ok(model);
+      assert.equal(model.primaryPreviewPath, 'parametric_box.stl');
+      assert.equal(model.parameters[0]?.labelZh, '总体宽度');
+      assert.equal(model.parameters[0]?.groupZh, '外形尺寸');
+      await rebuildModelWithParameters({
+        pythonExecutable: VENV_PYTHON,
+        request: {
+          primaryPreviewPath: model.primaryPreviewPath,
+          sourceHash: model.sourceHash,
+          sourcePath: model.sourcePath,
+          values: { 'overall-width': 24 },
+        },
+        workspaceRoot: root,
+      });
+      const report = JSON.parse(
+        await readFile(join(root, 'parametric_box_report.json'), 'utf8'),
+      ) as {
+        parameters: Record<string, { group_zh?: string; label_zh?: string }>;
+        shape: { bbox_mm: { size: number[] } };
+      };
+      assert.deepEqual(report.shape.bbox_mm.size, [24, 12, 6]);
+      assert.equal(report.parameters['overall-width']?.label_zh, '总体宽度');
+      assert.equal(report.parameters['overall-width']?.group_zh, '外形尺寸');
+      assert.match(
+        await readFile(join(root, 'parametric_box.py'), 'utf8'),
+        /"overall-width", 24\.0/u,
+      );
+      const [rebuiltModel] = await parameterModelsForWorkspace(root, VENV_PYTHON);
+      assert.equal(rebuiltModel?.parameters[0]?.kind, 'number');
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  'treats the combined 3MF as the adjustable top-level multi-color preview',
+  { skip: !existsSync(VENV_PYTHON) },
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), 'amagine-color-parameter-'));
+    try {
+      const skillRoot = join(PROJECT_ROOT, 'skills', 'text-a3d-color');
+      const source = `import sys
+sys.path.insert(0, ${JSON.stringify(skillRoot)})
+from build123d import Box, Pos
+from cad_helpers import export_regions, observe, parameter
+
+NAME = "color_bar"
+WIDTH = parameter(
+    "overall-width", 20.0,
+    min_value=10.0, max_value=30.0, step=0.5,
+    unit="mm", label="Overall width", group="Envelope",
+    affects=("complete-parent", "left-region", "right-region"),
+)
+left = Box(WIDTH / 2, 10, 5)
+right = Pos(WIDTH / 2, 0, 0) * Box(WIDTH / 2, 10, 5)
+parent = left + right
+observe(parent, "complete-parent", "parent")
+observe(left, "left-region", "color-region")
+observe(right, "right-region", "color-region")
+regions = {
+    "left": (left, "#F05A35"),
+    "right": (right, "#171717"),
+}
+
+if __name__ == "__main__":
+    export_regions(regions, NAME, parent=parent, source_path=__file__)
+`;
+      await writeFile(join(root, 'color_bar.py'), source);
+      await execFileAsync(VENV_PYTHON, ['color_bar.py'], { cwd: root });
+      const [model] = await parameterModelsForWorkspace(root, VENV_PYTHON);
+      assert.ok(model);
+      assert.equal(model.primaryPreviewPath, 'color_bar.3mf');
+      assert.deepEqual(
+        model.artifactPaths.slice().sort(),
+        [
+          'color_bar-left.stl',
+          'color_bar-right.stl',
+          'color_bar.3mf',
+          'color_bar.step',
+        ].sort(),
+      );
+      await rebuildModelWithParameters({
+        pythonExecutable: VENV_PYTHON,
+        request: {
+          primaryPreviewPath: model.primaryPreviewPath,
+          sourceHash: model.sourceHash,
+          sourcePath: model.sourcePath,
+          values: { 'overall-width': 24 },
+        },
+        workspaceRoot: root,
+      });
+      const report = JSON.parse(
+        await readFile(join(root, 'color_bar_report.json'), 'utf8'),
+      ) as { features: { 'complete-parent': { bounds_mm: { size: number[] } } } };
+      assert.deepEqual(
+        report.features['complete-parent'].bounds_mm.size,
+        [24, 10, 5],
+      );
+      assert.ok((await readFile(join(root, 'color_bar.3mf'))).byteLength > 0);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  },
+);

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -213,3 +213,37 @@ test('discovers artifacts only inside the selected session workspace', async () 
     await rm(root, { force: true, recursive: true });
   }
 });
+
+test('marks the build report top-level preview as featured', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'amagine-featured-model-'));
+  try {
+    const selectedRoot = sessionWorkspaceRoot(root, SESSION_ID)!;
+    await mkdir(selectedRoot, { recursive: true });
+    const sourcePath = join(selectedRoot, 'part.py');
+    const stlPath = join(selectedRoot, 'part.stl');
+    const stepPath = join(selectedRoot, 'part.step');
+    await writeFile(sourcePath, 'print("part")\n');
+    await writeFile(stlPath, 'solid part\nendsolid part\n');
+    await writeFile(stepPath, 'step');
+    await writeFile(
+      join(selectedRoot, 'part_report.json'),
+      JSON.stringify({
+        artifacts: {
+          step: { path: stepPath },
+          stl: { path: stlPath },
+        },
+        part: 'part',
+        schema: 'evidence-cad-build/v2',
+        source: { path: sourcePath },
+      }),
+    );
+
+    const collection = await userSessionArtifacts(root, SESSION_ID);
+    assert.equal(
+      collection?.artifacts.find(({ featured }) => featured)?.path,
+      'part.stl',
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## 背景

因版本更新导致代码管理混乱，遗漏了参数化建模的关键代码，右侧参数面板因此退化为静态占位，用户调整参数时无法将变化传递到 build123d 源码和最终模型。本 PR 重新载入这部分能力，并结合当前项目结构进行了适配性优化调整。

## 主要改动

- 增加显式、带边界的 parameter() 参数声明，支持数值范围、步长、单位、分组、关联特征及中英文名称。
- 使用 Python AST 检查和改写参数默认值，避免通过正则猜测普通常量，并正确支持负数等合法字面量。
- 增加完整模型重建流程：单色模型重新生成组合 STL、STEP 和报告；多色模型重新生成所有区域 STL、顶层 3MF、STEP 和报告。
- 仅在组合 STL 或顶层 3MF 预览时启用参数调整，局部 STL、STEP、源码和报告不会误触发完整模型控制。
- 在 session 内的隐藏临时目录进行构建和校验，全部产物成功后再原子发布；失败时保留原源码和原模型。
- 增加 Session 参数查询、重建 API 及共享并发锁，避免参数重建与 Agent 建模同时写入同一工作区。
- 将参数面板按“外形尺寸”“外观处理”“细节”等元数据分组，滑块两端明确显示 MIN/MAX，并支持中英文界面回退。
- 更新单色与多色建模 Skill，使后续生成的 build123d 源码稳定声明可调参数及双语展示信息。

## 兼容性与防护

- 现有未声明 parameter() 的模型继续正常预览，只显示无可调参数状态。
- 中文元数据为可选展示字段，缺失或无效时回退英文，不阻断 CAD 构建。
- 重建请求校验参数 ID、范围、步长、源码哈希和顶层产物归属。
- 构建过程设置超时与输出上限，并要求构建报告拥有的完整产物集全部重新生成。

## 验证

- npm test：51 项测试通过。
- npm run typecheck：通过。
- npm run build：通过。
- npm run licenses:check：通过。
- 使用真实 build123d 单色 STL 和多色 3MF 完成端到端重建验证。
- 使用现有参数化模型完成中文/英文、分组、MIN/MAX 和非顶层文件禁用状态的页面验证。

Closes #2
