### PR TITLE
Add printer-aware printability guardrails to CAD skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,7 @@ jobs:
       - run: npm run licenses:check
       - run: npm run typecheck
       - run: npm test
+      - run: npm run python:setup
+      - run: npm run test:python
       - run: npm run build
       - run: npm audit --audit-level=high

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -32,6 +32,7 @@ Technology.
 | build123d | `0.11.1` | Apache-2.0 | [`build123d.txt`](../public/licenses/build123d.txt), [`build123d-notice.txt`](../public/licenses/build123d-notice.txt) |
 | Open CASCADE Technology / CadQuery OCP | OCCT `7.9.3`, OCP `7.9.3.1.1` | LGPL-2.1 with Open CASCADE exception | [`opencascade-lgpl-2.1.txt`](../public/licenses/opencascade-lgpl-2.1.txt), [`opencascade-exception.txt`](../public/licenses/opencascade-exception.txt) |
 | trimesh | `5.0.0` | MIT | [`trimesh.txt`](../public/licenses/trimesh.txt) |
+| Rtree | `1.4.1` | MIT | [`rtree.txt`](../public/licenses/rtree.txt) |
 | lib3mf | `2.5.0` | BSD-2-Clause | [`lib3mf.txt`](../public/licenses/lib3mf.txt) |
 
 The complete production npm dependency graph and SPDX expressions are recorded

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "python:setup": "node scripts/setup-python.mjs",
     "start": "npm run python:setup && tsx server/index.ts",
     "test": "node --import tsx --test tests/*.test.ts",
+    "test:python": "node scripts/test-python.mjs",
     "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {

--- a/public/licenses/rtree.txt
+++ b/public/licenses/rtree.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018: Sean C. Gillies, Howard Butler and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ lib3mf==2.5.0
 matplotlib==3.10.9
 numpy==2.2.6
 pillow==12.3.0
+rtree==1.4.1
 trimesh==5.0.0

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -29,6 +29,7 @@ const requiredFiles = [
   'opencascade-lgpl-2.1.txt',
   'pi.txt',
   'react.txt',
+  'rtree.txt',
   'three.txt',
   'trimesh.txt',
 ];

--- a/scripts/setup-python.mjs
+++ b/scripts/setup-python.mjs
@@ -108,7 +108,7 @@ const venvPython = environmentPython();
 if (currentMarker === fingerprint && existsSync(venvPython)) {
   const check = run(
     venvPython,
-    ['-c', 'import build123d, lib3mf, matplotlib, numpy, PIL, trimesh'],
+    ['-c', 'import build123d, lib3mf, matplotlib, numpy, PIL, rtree, trimesh'],
     { capture: true },
   );
   if (check.status === 0) {
@@ -150,7 +150,7 @@ if (installed.status !== 0) {
 
 const verified = run(
   venvPython,
-  ['-c', 'import build123d, lib3mf, matplotlib, numpy, PIL, trimesh'],
+  ['-c', 'import build123d, lib3mf, matplotlib, numpy, PIL, rtree, trimesh'],
   { capture: true },
 );
 if (verified.status !== 0) {

--- a/scripts/test-python.mjs
+++ b/scripts/test-python.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const python =
+  process.platform === 'win32'
+    ? join(root, '.venv', 'Scripts', 'python.exe')
+    : join(root, '.venv', 'bin', 'python');
+const result = spawnSync(
+  python,
+  ['-m', 'unittest', 'discover', '-s', 'tests/python', '-p', 'test_*.py'],
+  { cwd: root, stdio: 'inherit' },
+);
+if (result.error) {
+  console.error(`Python tests could not start: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/server/python-runtime.ts
+++ b/server/python-runtime.ts
@@ -27,7 +27,7 @@ export function activateProjectPython(projectRoot: string): PythonHealth {
     executable,
     [
       '-c',
-      'import platform, build123d, lib3mf, matplotlib, numpy, PIL, trimesh; print(platform.python_version())',
+      'import platform, build123d, lib3mf, matplotlib, numpy, PIL, rtree, trimesh; print(platform.python_version())',
     ],
     { encoding: 'utf8' },
   );

--- a/skills/text-a3d-color/SKILL.md
+++ b/skills/text-a3d-color/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Evidence-driven multi-color CAD and manufacturing-region synthesis. Creates
   per-region STLs, a colored 3MF, and STEP assembly from explicit color
   semantics, deterministic palette reduction, strict overlap/coverage checks,
-  archive color readback, provenance hashes, and mandatory colored-view review.
+  archive color readback, pinned Bambu printability evidence, provenance
+  hashes, and mandatory colored-view review.
   Takes priority when reference colors identify screens, controls, text/logos,
   materials, inlays, functional regions, or the object's recognizable palette,
   even if the user does not mention multi-color, 3MF, or AMS.
@@ -23,18 +24,22 @@ session working directory.
 
 - `reference_analyze.py` extracts objective image/pixel/palette evidence
 - `palette_plan.py` reduces source colors into a deterministic filament plan
+- `bambu_profile.py` resolves this skill's pinned Bambu machine/process limits
 - `intent_contract.py` validates color semantics and boundaries before geometry
 - `examples/intent.example.json` is a copyable valid color contract
 - `cad_helpers.py` validates regions, optional parent coverage, and provenance
 - `export_3mf.py` writes a shared palette and reads object colors from 3MF XML
-- `qa_check.py` audits each exported region mesh
+- `qa_check.py` audits region topology and the combined manufacturing mesh
 - `assembly_check.py` cross-checks build regions against the stored 3MF colors
 - `render_preview.py` creates orthographic, hash-bound color evidence
 - `freshness_check.py` and `compare_silhouette.py` close the run
 - Read `references/evidence-contract.md` for every generated color task
 - Read `references/color-architecture.md` before choosing region interfaces
+- Read `references/bambu-printability.md` before every printable color task
 
-Requires build123d, lib3mf, trimesh, matplotlib, Pillow, and NumPy.
+Requires build123d, lib3mf, trimesh, Rtree, matplotlib, Pillow, and NumPy. When
+running outside Amagine3D's managed session, initialize the repository runtime
+and use its Python executable instead of an unrelated system Python.
 
 ## 0. Route and interpret color
 
@@ -47,14 +52,23 @@ Distinguish permanent printed color from transient display content. A physical
 LED/LCD is normally one screen region; model individual lit pixels only for a
 requested static decorative face or mosaic.
 
+RGB stored in a 3MF does not prove optical behavior. Record every region as
+`opaque`, `translucent`, or `transparent` in the intent. Non-opaque regions
+also require the generated material plan and explicit slicer filament mapping.
+
 ## 1. Open the evidence run
 
 Create a marker before new files:
 
 ```bash
 python "<SKILL_DIR>/freshness_check.py" --mark ".<name>.generation-start"
+python "<SKILL_DIR>/bambu_profile.py" --machine <machine-id> --nozzle <0.2|0.4|0.6|0.8> --tool <N> --out "<name>_printer-profile.json"
 python "<SKILL_DIR>/reference_analyze.py" "/absolute/reference.png" --out "<name>_reference.json"
 ```
+
+Honor a named user or project printer. Otherwise omit `--machine` to resolve
+the conservative A1 mini default and record the assumption. Read the generated
+profile before modeling; never change it later merely to clear QA.
 
 When source colors exceed available filaments, create a proposed plan:
 
@@ -70,16 +84,24 @@ frequency: rare logo/control colors are not disposable. Validate:
 python "<SKILL_DIR>/intent_contract.py" "<name>_intent.json"
 ```
 
+The contract must bind the profile hash, build orientation, support policy,
+wall target, functional acceptance criteria, critical feature IDs, and each
+region's optical transmission. Critical IDs must later resolve to named build
+evidence; for routed cavities, observe a representative local cross-section.
+
 ## 2. Design region architecture
 
-Read `references/color-architecture.md`. Choose parent split, inset, raised
-overlay, or separately assembled insert for every boundary. Build the complete
-parent form first when regions collectively represent one body; this enables
-coverage checking and prevents invented gaps.
+Read `references/color-architecture.md` and
+`references/bambu-printability.md`. Choose parent split, inset, raised overlay,
+or separately assembled insert for every boundary. Build the complete parent
+form first when regions collectively represent one co-printed body; this
+enables coverage checking, a combined manufacturing STL, and support analysis
+without false positives at material interfaces.
 
-The color contract defines region name, hex, purpose, geometric boundary, and
-evidence. Do not collapse distinct semantic regions merely to fit an arbitrary
-palette limit; record every compromise.
+The color contract defines region name, hex, optical material, purpose,
+geometric boundary, and evidence. Use the profile's line-width and wall targets
+for every boundary. Do not collapse distinct semantic regions merely to fit an
+arbitrary palette limit; record every compromise.
 
 ## 3. Build and export strict regions
 
@@ -109,14 +131,28 @@ if __name__ == "__main__":
 
 For separately assembled inserts whose union intentionally differs from one
 parent, omit `parent=` only after recording that architecture in the contract.
+`export_regions()` always emits `<name>-combined.stl`; when `parent=` is
+provided the combined file is the coverage-checked parent without internal
+material-interface faces. It also emits `<name>_material-plan.json` because 3MF
+RGB values cannot encode translucency or filament chemistry.
 
 ## 4. Audit meshes, archive, and appearance
 
-Audit every region STL using its expected component count and dimensions:
+Audit every region STL for topology only. Do not run overhang checks on an
+isolated co-printed region because adjacent materials may provide support:
 
 ```bash
-python "<SKILL_DIR>/qa_check.py" "<name>-<region>.stl" --region <region> --components <N> --out "<name>-<region>_mesh-audit.json"
+python "<SKILL_DIR>/qa_check.py" "<name>-<region>.stl" --topology-only --region <region> --components <N> --out "<name>-<region>_mesh-audit.json"
 ```
+
+Run Bambu manufacturing checks exactly once on the combined STL:
+
+```bash
+python "<SKILL_DIR>/qa_check.py" "<name>-combined.stl" --profile "<name>_printer-profile.json" --intent "<name>_intent.json" --report "<name>_report.json" --components <N> --expect-x <X> --expect-y <Y> --expect-z <Z> --tol <T> --require-z0 --out "<name>-combined_mesh-audit.json"
+```
+
+Read every `fail`, `warning`, and `not_evaluated` result. A region topology
+pass cannot replace the combined bed-fit, wall, feature, or overhang evidence.
 
 Then verify that 3MF names and colors match the build report:
 
@@ -128,7 +164,7 @@ Render all regions with contract colors, producing four views and the matched
 view:
 
 ```bash
-python "<SKILL_DIR>/render_preview.py" --part "<name>-<region-a>.stl=#RRGGBB" --part "<name>-<region-b>.stl=#RRGGBB" --out "<name>_views.png" --reference-view <front|side|top|isometric> --reference-out "<name>_reference-view.png" --report "<name>_render.json"
+python "<SKILL_DIR>/render_preview.py" --part "<name>-<region-a>.stl=#RRGGBB" --part "<name>-<region-b>.stl=#RRGGBB" --out "<name>_views.png" --reference-view <front|side|top|bottom|isometric> --reference-out "<name>_reference-view.png" --report "<name>_render.json"
 ```
 
 Use `read` on both. Judge geometry landmarks, silhouette/depth, region
@@ -138,15 +174,22 @@ Use silhouette scoring only for a corresponding orthographic/flat source.
 ## 5. Repair and close
 
 Repair the failed evidence class: parent geometry, region boundary, palette
-mapping, mesh topology, archive assignment, or visual placement. Every change
-requires rebuild, all affected region audits, assembly audit, render, and read.
+mapping, mesh topology, bed fit, feature size, wall thickness, overhang,
+archive assignment, or visual placement. Never lower the profile limits or
+scale fixed user dimensions to clear QA. Every change requires rebuild, all
+affected region audits, combined audit, assembly audit, render, and read.
 Maximum three evidence-repair passes; disclose remaining failures at the cap.
 
-Freshness must cover intent, palette plan when used, source, every region STL,
-STEP, 3MF, build report, mesh audits, assembly audit, visual previews, and the
-render evidence report.
+Freshness must cover the printer profile, intent, palette plan when used,
+source, every region STL, combined STL, STEP, 3MF, material plan, build report,
+region mesh audits, combined manufacturing audit, assembly audit, visual
+previews, and the render evidence report.
 
 Deliver the complete evidence bundle. Report geometry, region integrity, 3MF
-readback, freshness, visual fidelity, palette fidelity, and printability as
-separate statuses. For Bambu Studio, prefer the colored 3MF; region STLs remain
-the fallback for manual filament assignment.
+readback, material/transmission assignment, freshness, visual fidelity, palette
+fidelity, bed fit, feature resolution, walls, and overhangs as separate
+statuses. Summarize the combined result as `print preflight passed`, `print
+preflight passed with warnings`, or `print preflight failed`. Report `actual
+slicer validation: not evaluated` unless a real Bambu Studio or equivalent
+slicer run was completed. For Bambu Studio, prefer the colored 3MF; region STLs
+remain the fallback for manual filament assignment.

--- a/skills/text-a3d-color/assembly_check.py
+++ b/skills/text-a3d-color/assembly_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from hashlib import sha256
 import json
 from pathlib import Path
 import sys
@@ -20,6 +21,7 @@ def main() -> int:
 
     report = json.loads(Path(args.report).read_text(encoding="utf-8"))
     archive = inspect_color_archive(args.three_mf)
+    archive_hash = sha256(Path(args.three_mf).read_bytes()).hexdigest()
     expected = {
         name: item["color"].upper() for name, item in report.get("regions", {}).items()
     }
@@ -27,6 +29,19 @@ def main() -> int:
         item["name"]: (item["color"] or "").upper() for item in archive["objects"]
     }
     checks = [
+        {
+            "name": "build_report_schema",
+            "pass": report.get("schema") == "evidence-color-build/v3",
+            "expected": "evidence-color-build/v3",
+            "observed": report.get("schema"),
+        },
+        {
+            "name": "archive_provenance",
+            "pass": report.get("artifacts", {}).get("3mf", {}).get("sha256")
+            == archive_hash,
+            "expected": report.get("artifacts", {}).get("3mf", {}).get("sha256"),
+            "observed": archive_hash,
+        },
         {
             "name": "region_names",
             "pass": set(expected) == set(observed),
@@ -56,11 +71,51 @@ def main() -> int:
             "expected": f"<= {args.max_overlap}",
         })
 
+    material = report.get("material_semantics")
+    checks.append({
+        "name": "material_plan_present",
+        "pass": isinstance(material, dict),
+        "expected": "evidence-color-material-plan/v1",
+        "observed": material.get("schema") if isinstance(material, dict) else None,
+    })
+    if isinstance(material, dict):
+        checks.append({
+            "name": "material_plan_schema",
+            "pass": material.get("schema") == "evidence-color-material-plan/v1",
+            "expected": "evidence-color-material-plan/v1",
+            "observed": material.get("schema"),
+        })
+        material_regions = {
+            item.get("name"): item for item in material.get("regions", [])
+        }
+        checks.append({
+            "name": "material_region_names",
+            "pass": set(material_regions) == set(expected),
+            "expected": sorted(expected),
+            "observed": sorted(material_regions),
+        })
+        checks.append({
+            "name": "material_region_colors",
+            "pass": all(
+                str(material_regions[name].get("color", "")).upper() == color
+                for name, color in expected.items()
+                if name in material_regions
+            ),
+            "expected": expected,
+            "observed": {
+                name: str(item.get("color", "")).upper()
+                for name, item in material_regions.items()
+            },
+        })
+
     result = {
         "archive": archive,
         "checks": checks,
         "pass": all(check["pass"] for check in checks),
-        "schema": "color-assembly-audit/v2",
+        "requires_manual_slicer_assignment": bool(
+            material and material.get("requires_manual_slicer_assignment")
+        ),
+        "schema": "color-assembly-audit/v3",
     }
     payload = json.dumps(result, indent=2)
     if args.out:

--- a/skills/text-a3d-color/bambu_profile.py
+++ b/skills/text-a3d-color/bambu_profile.py
@@ -1,0 +1,146 @@
+"""Resolve a pinned Bambu machine, nozzle, process, and tool profile for color CAD."""
+
+from __future__ import annotations
+
+import argparse
+from hashlib import sha256
+import json
+from pathlib import Path
+import sys
+
+
+CATALOG_PATH = Path(__file__).with_name("references") / "bambu-profiles.json"
+
+
+def load_catalog() -> dict:
+    data = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    if data.get("schema") != "amagine-bambu-profile-catalog/v1":
+        raise ValueError("unsupported Bambu profile catalog schema")
+    return data
+
+
+def resolve_machine(catalog: dict, value: str | None) -> tuple[str, dict, bool]:
+    assumed = value is None
+    requested = value or catalog["default_machine"]
+    normalized = requested.strip().casefold()
+    for machine_id, machine in catalog["machines"].items():
+        if normalized in {machine_id.casefold(), machine["name"].casefold()}:
+            return machine_id, machine, assumed
+    available = ", ".join(sorted(catalog["machines"]))
+    raise ValueError(f"unknown Bambu machine {requested!r}; choose one of: {available}")
+
+
+def resolve_profile(
+    catalog: dict,
+    *,
+    machine_name: str | None,
+    nozzle: float,
+    tool_index: int,
+) -> dict:
+    machine_id, machine, assumed = resolve_machine(catalog, machine_name)
+    process_key = f"{nozzle:g}"
+    process = catalog["processes"].get(process_key)
+    if process is None:
+        available = ", ".join(sorted(catalog["processes"]))
+        raise ValueError(f"unsupported nozzle {nozzle:g} mm; choose one of: {available}")
+    tools = {int(item["index"]): item for item in machine["tools"]}
+    if tool_index not in tools:
+        available = ", ".join(str(index) for index in sorted(tools))
+        raise ValueError(
+            f"{machine['name']} has no tool {tool_index}; choose one of: {available}"
+        )
+    tool = tools[tool_index]
+    defaults = catalog["process_defaults"]
+    outer = float(process["outer_wall_line_width_mm"])
+    inner = float(process["inner_wall_line_width_mm"])
+    loops = int(process["wall_loops"])
+    return {
+        "derived": {
+            "arachne_min_bead_mm": round(
+                nozzle * defaults["arachne_min_bead_nozzle_percent"] / 100, 5
+            ),
+            "arachne_min_feature_mm": round(
+                nozzle * defaults["arachne_min_feature_nozzle_percent"] / 100, 5
+            ),
+            "process_wall_target_mm": round(outer + inner * max(loops - 1, 0), 5),
+            "single_line_floor_mm": outer,
+        },
+        "id": f"bbl-{machine_id}-{process_key}-t{tool_index}-standard",
+        "machine": {
+            "bed_polygon_mm": machine["bed_polygon_mm"],
+            "excluded_polygons_mm": machine["excluded_polygons_mm"],
+            "id": machine_id,
+            "name": machine["name"],
+            "printable_height_mm": machine["printable_height_mm"],
+            "selected_tool": tool,
+        },
+        "process": {**defaults, **process},
+        "schema": "evidence-bambu-printer-profile/v1",
+        "selection": {
+            "assumed_default_machine": assumed,
+            "tool_index": tool_index,
+        },
+        "upstream": catalog["upstream"],
+        "vendor": "Bambu Lab",
+    }
+
+
+def serialize(data: dict) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--machine", help="machine ID or official Bambu model name")
+    parser.add_argument("--nozzle", type=float, default=0.4)
+    parser.add_argument("--tool", type=int, default=0)
+    parser.add_argument("--list", action="store_true", help="list supported machines")
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    try:
+        catalog = load_catalog()
+        if args.list:
+            result = {
+                "default_machine": catalog["default_machine"],
+                "machines": [
+                    {
+                        "id": machine_id,
+                        "name": machine["name"],
+                        "tools": [item["index"] for item in machine["tools"]],
+                    }
+                    for machine_id, machine in catalog["machines"].items()
+                ],
+                "nozzles_mm": [float(value) for value in catalog["processes"]],
+                "schema": catalog["schema"],
+                "upstream": catalog["upstream"],
+            }
+            print(serialize(result), end="")
+            return 0
+        profile = resolve_profile(
+            catalog,
+            machine_name=args.machine,
+            nozzle=args.nozzle,
+            tool_index=args.tool,
+        )
+    except Exception as error:
+        print(json.dumps({"error": str(error), "pass": False}, indent=2))
+        return 2
+
+    payload = serialize(profile)
+    if args.out:
+        output = Path(args.out)
+        output.write_text(payload, encoding="utf-8")
+        artifact = {
+            "path": str(output.resolve()),
+            "profile_id": profile["id"],
+            "sha256": sha256(output.read_bytes()).hexdigest(),
+        }
+        print(json.dumps(artifact, indent=2))
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/text-a3d-color/cad_helpers.py
+++ b/skills/text-a3d-color/cad_helpers.py
@@ -19,7 +19,7 @@ class RegionInvariantError(RuntimeError):
 
 
 _FEATURES: dict[str, dict] = {}
-_OPERATIONS: list[dict] = []
+_EVENTS: list[dict] = []
 _REGION_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
 _HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
 
@@ -36,7 +36,7 @@ def _valid(shape) -> bool:
 def _shape_record(shape) -> dict:
     bounds = shape.bounding_box()
     return {
-        "bounds_mm": {
+        "bbox_mm": {
             "min": [round(bounds.min.X, 4), round(bounds.min.Y, 4), round(bounds.min.Z, 4)],
             "max": [round(bounds.max.X, 4), round(bounds.max.Y, 4), round(bounds.max.Z, 4)],
             "size": [
@@ -59,12 +59,18 @@ def observe(shape, feature_id: str, role: str = "feature") -> None:
 
 def checked_cut(body, tool, feature_id: str, min_removed_mm3: float = 0.001):
     before = float(body.volume)
+    tool_stats = _shape_record(tool)
     try:
         result = body - tool
     except Exception as error:
         raise RegionInvariantError(f"cut {feature_id!r} failed: {error}") from error
     removed = before - float(result.volume)
-    _OPERATIONS.append({"id": feature_id, "kind": "cut", "removed_mm3": removed})
+    _EVENTS.append({
+        "id": feature_id,
+        "kind": "cut",
+        "removed_mm3": round(removed, 6),
+        "tool": tool_stats,
+    })
     if removed < min_removed_mm3:
         raise RegionInvariantError(f"cut {feature_id!r} missed the parent solid")
     if not _valid(result):
@@ -86,8 +92,12 @@ def _checked_finish(shape, selector, size_mm: float, feature_id: str, kind: str)
         raise RegionInvariantError(f"{kind} {feature_id!r} failed: {error}") from error
     if not _valid(result):
         raise RegionInvariantError(f"{kind} {feature_id!r} produced invalid geometry")
-    _OPERATIONS.append({
-        "id": feature_id, "kind": kind, "size_mm": round(size_mm, 6),
+    _EVENTS.append({
+        "actual_mm": round(size_mm, 6),
+        "degraded": False,
+        "id": feature_id,
+        "kind": kind,
+        "requested_mm": size_mm,
     })
     return result
 
@@ -112,8 +122,8 @@ def export_regions(
     name: str,
     out_dir: str = ".",
     *,
+    intent_path: str,
     parent=None,
-    intent_path: str | None = None,
     source_path: str | None = None,
     max_coverage_error_mm3: float = 0.01,
 ) -> dict:
@@ -123,14 +133,42 @@ def export_regions(
 
     output = Path(out_dir)
     output.mkdir(parents=True, exist_ok=True)
+    intent = Path(intent_path).resolve()
+    try:
+        intent_data = json.loads(intent.read_text(encoding="utf-8"))
+    except Exception as error:
+        raise RegionInvariantError(f"could not read intent contract: {error}") from error
+    if intent_data.get("schema") != "evidence-color-intent/v3":
+        raise RegionInvariantError("intent contract must use evidence-color-intent/v3")
+    if intent_data.get("part") != name:
+        raise RegionInvariantError("intent part does not match the export name")
+    feature_items = intent_data.get("features", [])
+    declared_feature_ids = {
+        item.get("id") for item in feature_items if isinstance(item, dict)
+    }
+    raw_critical_features = intent_data.get("printability", {}).get(
+        "critical_features"
+    )
+    critical_feature_ids = (
+        set(raw_critical_features) if isinstance(raw_critical_features, list) else set()
+    )
+    if (
+        not feature_items
+        or len(declared_feature_ids) != len(feature_items)
+        or not critical_feature_ids
+        or not critical_feature_ids.issubset(declared_feature_ids)
+    ):
+        raise RegionInvariantError(
+            "intent critical features must uniquely reference declared features"
+        )
     report = {
         "built_at": datetime.now(timezone.utc).isoformat(),
+        "events": list(_EVENTS),
         "features": dict(_FEATURES),
-        "operations": list(_OPERATIONS),
         "overlaps_mm3": {},
         "part": name,
         "regions": {},
-        "schema": "evidence-color-build/v2",
+        "schema": "evidence-color-build/v3",
     }
 
     normalized: dict[str, tuple] = {}
@@ -146,6 +184,45 @@ def export_regions(
         normalized[region_name] = (shape, color)
         report["regions"][region_name] = {"color": color, **record}
 
+    declared_items = intent_data.get("color_regions", [])
+    declared = {
+        item.get("name"): item
+        for item in declared_items
+        if isinstance(item, dict)
+    }
+    if len(declared) != len(declared_items) or set(declared) != set(normalized):
+        raise RegionInvariantError(
+            "intent color-region names do not uniquely match exported region names"
+        )
+    material_regions = []
+    for region_name, (_, color) in normalized.items():
+        item = declared[region_name]
+        if str(item.get("hex", "")).upper() != color:
+            raise RegionInvariantError(
+                f"intent color for {region_name!r} does not match exported color"
+            )
+        material = item.get("material")
+        if not isinstance(material, dict):
+            raise RegionInvariantError(f"intent material for {region_name!r} is missing")
+        transmission = material.get("transmission")
+        if transmission not in {"opaque", "translucent", "transparent"}:
+            raise RegionInvariantError(
+                f"intent transmission for {region_name!r} is invalid"
+            )
+        filament = material.get("filament")
+        if transmission != "opaque" and not (
+            isinstance(filament, str) and filament.strip()
+        ):
+            raise RegionInvariantError(
+                f"non-opaque region {region_name!r} requires a filament assignment"
+            )
+        material_regions.append({
+            "color": color,
+            "filament": filament,
+            "name": region_name,
+            "transmission": transmission,
+        })
+
     names = list(normalized)
     for index, left in enumerate(names):
         for right in names[index + 1:]:
@@ -158,12 +235,12 @@ def export_regions(
 
     region_shapes = [shape for shape, _ in normalized.values()]
     region_volume = sum(float(shape.volume) for shape in region_shapes)
+    region_union = region_shapes[0]
+    for shape in region_shapes[1:]:
+        region_union = region_union + shape
     if parent is not None:
         if not _valid(parent):
             raise RegionInvariantError("coverage parent is invalid")
-        region_union = region_shapes[0]
-        for shape in region_shapes[1:]:
-            region_union = region_union + shape
         try:
             missing = float((parent - region_union).volume)
             outside = float((region_union - parent).volume)
@@ -198,6 +275,17 @@ def export_regions(
             "path": str(path.resolve()), "sha256": _digest(path),
         }
 
+    combined = parent if parent is not None else region_union
+    combined_record = _shape_record(combined)
+    if not combined_record["valid"]:
+        raise RegionInvariantError("combined manufacturing geometry is invalid")
+    combined_path = output / f"{name}-combined.stl"
+    export_stl(combined, str(combined_path), tolerance=0.01, angular_tolerance=0.1)
+    artifacts["stl:combined"] = {
+        "path": str(combined_path.resolve()), "sha256": _digest(combined_path),
+    }
+    report["combined"] = combined_record
+
     archive_path = output / f"{name}.3mf"
     report["three_mf"] = write_color_archive(entries, str(archive_path))
     artifacts["3mf"] = {"path": str(archive_path.resolve()), "sha256": _digest(archive_path)}
@@ -211,17 +299,33 @@ def export_regions(
     export_step(Compound(children=children), str(step_path), unit=Unit.MM)
     artifacts["step"] = {"path": str(step_path.resolve()), "sha256": _digest(step_path)}
 
+    material_plan_path = output / f"{name}_material-plan.json"
+    material_plan = {
+        "archive_encodes": ["region_name", "rgb"],
+        "archive_omits": ["filament", "transmission"],
+        "part": name,
+        "regions": material_regions,
+        "requires_manual_slicer_assignment": any(
+            item["transmission"] != "opaque" or item["filament"]
+            for item in material_regions
+        ),
+        "schema": "evidence-color-material-plan/v1",
+    }
+    material_plan_path.write_text(
+        json.dumps(material_plan, indent=2) + "\n", encoding="utf-8"
+    )
+    artifacts["material_plan"] = {
+        "path": str(material_plan_path.resolve()),
+        "sha256": _digest(material_plan_path),
+    }
+    report["material_semantics"] = material_plan
+
     source = Path(source_path or sys.argv[0]).resolve()
-    intent = Path(intent_path).resolve() if intent_path else None
     report["artifacts"] = artifacts
     report["source"] = (
         {"path": str(source), "sha256": _digest(source)} if source.is_file() else None
     )
-    report["intent"] = (
-        {"path": str(intent), "sha256": _digest(intent)}
-        if intent and intent.is_file()
-        else None
-    )
+    report["intent"] = {"path": str(intent), "sha256": _digest(intent)}
     report_path = output / f"{name}_report.json"
     report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(report, indent=2))

--- a/skills/text-a3d-color/examples/bambu-a1-mini-0.4-standard.example.json
+++ b/skills/text-a3d-color/examples/bambu-a1-mini-0.4-standard.example.json
@@ -1,0 +1,46 @@
+{
+  "derived": {
+    "arachne_min_bead_mm": 0.34,
+    "arachne_min_feature_mm": 0.1,
+    "process_wall_target_mm": 0.87,
+    "single_line_floor_mm": 0.42
+  },
+  "id": "bbl-a1-mini-0.4-t0-standard",
+  "machine": {
+    "bed_polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]],
+    "excluded_polygons_mm": [],
+    "id": "a1-mini",
+    "name": "Bambu Lab A1 mini",
+    "printable_height_mm": 180,
+    "selected_tool": {
+      "height_mm": 180,
+      "index": 0,
+      "polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]]
+    }
+  },
+  "process": {
+    "arachne_min_bead_nozzle_percent": 85,
+    "arachne_min_feature_nozzle_percent": 25,
+    "detect_thin_wall": false,
+    "inner_wall_line_width_mm": 0.45,
+    "layer_height_mm": 0.2,
+    "line_width_mm": 0.42,
+    "name": "0.20mm Standard",
+    "nozzle_diameter_mm": 0.4,
+    "outer_wall_line_width_mm": 0.42,
+    "support_enabled": false,
+    "support_threshold_angle_from_horizontal_deg": 30,
+    "support_type": "tree(auto)",
+    "wall_generator": "classic",
+    "wall_loops": 2
+  },
+  "schema": "evidence-bambu-printer-profile/v1",
+  "selection": {"assumed_default_machine": false, "tool_index": 0},
+  "upstream": {
+    "commit": "926a7192574bcb9b3a732e1ec59a46d79cb45466",
+    "release": "v02.08.02.61",
+    "repository": "https://github.com/bambulab/BambuStudio",
+    "vendor_config_version": "02.08.00.05"
+  },
+  "vendor": "Bambu Lab"
+}

--- a/skills/text-a3d-color/examples/intent.example.json
+++ b/skills/text-a3d-color/examples/intent.example.json
@@ -1,31 +1,63 @@
 {
-  "schema": "evidence-color-intent/v2",
+  "schema": "evidence-color-intent/v3",
   "part": "example-two-color-tile",
+  "task_mode": "specification",
   "representation": "relief",
+  "reference_files": [],
   "dimensions_mm": {
     "x": {"value": 40, "source": "user", "confidence": "high"},
     "y": {"value": 20, "source": "user", "confidence": "high"},
     "z": {"value": 4, "source": "inferred", "confidence": "medium"}
   },
+  "features": [
+    {
+      "id": "left-field",
+      "evidence": "The specification assigns the left half to the primary color.",
+      "acceptance": "The red field covers X=0 through X=20 mm without gaps."
+    },
+    {
+      "id": "right-field",
+      "evidence": "The specification assigns the right half to the secondary color.",
+      "acceptance": "The blue field covers X=20 through X=40 mm without gaps."
+    },
+    {
+      "id": "center-boundary",
+      "evidence": "The two fields meet at the specified center line.",
+      "acceptance": "The material boundary is a single vertical interface at X=20 mm."
+    }
+  ],
   "color_regions": [
     {
       "name": "left_field",
       "hex": "#CC2233",
       "purpose": "Primary identity field",
       "boundary": "Left half of the parent volume split at X=0",
-      "evidence": "Reference left field is red."
+      "evidence": "Specification assigns red to the left field.",
+      "material": {"transmission": "opaque"}
     },
     {
       "name": "right_field",
       "hex": "#2255CC",
       "purpose": "Secondary identity field",
       "boundary": "Right half of the parent volume split at X=0",
-      "evidence": "Reference right field is blue."
+      "evidence": "Specification assigns blue to the right field.",
+      "material": {"transmission": "opaque"}
     }
   ],
   "palette_reduction": {
     "applied": false,
     "reason": "The two semantic colors map directly to two filaments."
+  },
+  "printability": {
+    "profile": {
+      "path": "bambu-a1-mini-0.4-standard.example.json",
+      "sha256": "f5bdfcc78cc4e55289a4a259c6d94a6cab18534494d50655b5f0d1d67b132386"
+    },
+    "build_axis": "+Z",
+    "bed_contact": "z-min",
+    "support_policy": "support-free",
+    "minimum_wall_target_mm": 0.87,
+    "critical_features": ["left-field", "right-field", "center-boundary"]
   },
   "visual": {
     "required": true,

--- a/skills/text-a3d-color/intent_contract.py
+++ b/skills/text-a3d-color/intent_contract.py
@@ -3,20 +3,72 @@
 from __future__ import annotations
 
 import json
+from hashlib import sha256
 from pathlib import Path
 import re
 import sys
 
 
 HEX = re.compile(r"^#[0-9A-Fa-f]{6}$")
+MODES = {
+    "inspect",
+    "recognizable-form",
+    "reference-inspired",
+    "reference-reproduction",
+    "specification",
+}
+SOURCES = {"inferred", "reference", "standard", "user"}
+CONFIDENCE = {"high", "low", "medium"}
+TRANSMISSION = {"opaque", "translucent", "transparent"}
+VIEWS = {"bottom", "front", "isometric", "side", "top"}
 
 
-def validate(data: dict) -> list[str]:
+def _positive_number(value) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0
+
+
+def _load_profile(reference: dict, base_dir: Path | None, errors: list[str]) -> dict | None:
+    if not isinstance(reference, dict):
+        errors.append("printability.profile must be an object")
+        return None
+    raw_path = reference.get("path")
+    digest = reference.get("sha256")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        errors.append("printability.profile.path is required")
+        return None
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        errors.append("printability.profile.sha256 must be a lowercase SHA-256 digest")
+    if base_dir is None:
+        return None
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = base_dir / path
+    try:
+        payload = path.read_bytes()
+        profile = json.loads(payload)
+    except Exception as error:
+        errors.append(f"printability profile cannot be read: {error}")
+        return None
+    if isinstance(digest, str) and sha256(payload).hexdigest() != digest:
+        errors.append("printability profile hash does not match")
+    if profile.get("schema") != "evidence-bambu-printer-profile/v1":
+        errors.append("printability profile schema is unsupported")
+    if profile.get("vendor") != "Bambu Lab":
+        errors.append("printability profile vendor must be Bambu Lab")
+    for key in ("single_line_floor_mm", "process_wall_target_mm"):
+        if not _positive_number(profile.get("derived", {}).get(key)):
+            errors.append(f"printability profile derived.{key} must be positive")
+    return profile
+
+
+def validate(data: dict, base_dir: Path | None = None) -> list[str]:
     errors: list[str] = []
-    if data.get("schema") != "evidence-color-intent/v2":
-        errors.append("schema must be evidence-color-intent/v2")
+    if data.get("schema") != "evidence-color-intent/v3":
+        errors.append("schema must be evidence-color-intent/v3")
     if not re.fullmatch(r"[a-z0-9]+(?:[-_][a-z0-9]+)*", str(data.get("part", ""))):
         errors.append("part must be a lowercase filename-safe slug")
+    if data.get("task_mode") not in MODES:
+        errors.append("task_mode is invalid")
     if data.get("representation") not in {
         "full-3d", "orthographic-solid", "relief", "surface-led",
     }:
@@ -28,10 +80,38 @@ def validate(data: dict) -> list[str]:
     else:
         for axis in "xyz":
             item = dimensions.get(axis)
-            if not isinstance(item, dict) or not isinstance(item.get("value"), (int, float)):
-                errors.append(f"dimensions_mm.{axis}.value is required")
-            elif item["value"] <= 0:
+            if not isinstance(item, dict):
+                errors.append(f"dimensions_mm.{axis} is required")
+                continue
+            if not _positive_number(item.get("value")):
                 errors.append(f"dimensions_mm.{axis}.value must be positive")
+            if item.get("source") not in SOURCES:
+                errors.append(f"dimensions_mm.{axis}.source must be evidence-scoped")
+            if item.get("confidence") not in CONFIDENCE:
+                errors.append(f"dimensions_mm.{axis}.confidence is invalid")
+
+    feature_ids: set[str] = set()
+    features = data.get("features")
+    if not isinstance(features, list) or not features:
+        errors.append("features must be a non-empty list")
+    else:
+        ids = []
+        for index, feature in enumerate(features):
+            if not isinstance(feature, dict):
+                errors.append(f"features[{index}] must be an object")
+                continue
+            feature_id = feature.get("id")
+            ids.append(feature_id)
+            if not re.fullmatch(
+                r"[a-z0-9]+(?:[-_][a-z0-9]+)*", str(feature_id or "")
+            ):
+                errors.append(f"features[{index}].id is invalid")
+            for key in ("evidence", "acceptance"):
+                if not isinstance(feature.get(key), str) or not feature[key].strip():
+                    errors.append(f"features[{index}].{key} is required")
+        if len(ids) != len(set(ids)):
+            errors.append("feature ids must be unique")
+        feature_ids = {item for item in ids if isinstance(item, str)}
 
     regions = data.get("color_regions")
     if not isinstance(regions, list) or len(regions) < 2:
@@ -50,6 +130,30 @@ def validate(data: dict) -> list[str]:
             for key in ("purpose", "boundary", "evidence"):
                 if not isinstance(region.get(key), str) or not region[key].strip():
                     errors.append(f"color_regions[{index}].{key} is required")
+            material = region.get("material")
+            if not isinstance(material, dict):
+                errors.append(f"color_regions[{index}].material is required")
+            else:
+                transmission = material.get("transmission")
+                filament = material.get("filament")
+                if transmission not in TRANSMISSION:
+                    errors.append(
+                        f"color_regions[{index}].material.transmission is invalid"
+                    )
+                if filament is not None and (
+                    not isinstance(filament, str) or not filament.strip()
+                ):
+                    errors.append(
+                        f"color_regions[{index}].material.filament must be a "
+                        "non-empty string when present"
+                    )
+                if transmission in {"translucent", "transparent"} and not (
+                    isinstance(filament, str) and filament.strip()
+                ):
+                    errors.append(
+                        f"color_regions[{index}].material.filament is required "
+                        "for non-opaque regions"
+                    )
         if len(names) != len(set(names)):
             errors.append("color region names must be unique")
 
@@ -58,10 +162,53 @@ def validate(data: dict) -> list[str]:
         errors.append("visual.required must be true for color generation")
     elif not isinstance(visual.get("landmarks"), list) or not visual["landmarks"]:
         errors.append("visual.landmarks must be non-empty")
+    elif visual.get("reference_view") not in VIEWS:
+        errors.append("visual.reference_view is invalid")
     if not isinstance(data.get("palette_reduction"), dict):
         errors.append("palette_reduction decision is required")
     if not isinstance(data.get("assumptions"), list):
         errors.append("assumptions must be a list")
+    if not isinstance(data.get("reference_files"), list):
+        errors.append("reference_files must be a list")
+
+    printability = data.get("printability")
+    if not isinstance(printability, dict):
+        errors.append("printability must define a Bambu manufacturing plan")
+    else:
+        profile = _load_profile(printability.get("profile"), base_dir, errors)
+        if printability.get("build_axis") != "+Z":
+            errors.append("printability.build_axis must be +Z")
+        if printability.get("bed_contact") != "z-min":
+            errors.append("printability.bed_contact must be z-min")
+        if printability.get("support_policy") not in {
+            "support-free",
+            "supports-allowed",
+            "supports-required",
+        }:
+            errors.append("printability.support_policy is invalid")
+        target = printability.get("minimum_wall_target_mm")
+        if not _positive_number(target):
+            errors.append("printability.minimum_wall_target_mm must be positive")
+        elif profile is not None:
+            process_target = profile["derived"]["process_wall_target_mm"]
+            if target + 1e-9 < process_target:
+                errors.append(
+                    "printability.minimum_wall_target_mm must meet the selected "
+                    f"process wall target ({process_target:g} mm)"
+                )
+        critical = printability.get("critical_features")
+        if not isinstance(critical, list) or not critical or not all(
+            isinstance(item, str) and item.strip() for item in critical
+        ):
+            errors.append(
+                "printability.critical_features must be a non-empty list of feature IDs"
+            )
+        elif len(critical) != len(set(critical)):
+            errors.append("printability.critical_features must be unique")
+        elif not set(critical).issubset(feature_ids):
+            errors.append(
+                "printability.critical_features must reference declared feature IDs"
+            )
     return errors
 
 
@@ -72,7 +219,7 @@ def main() -> int:
     path = Path(sys.argv[1])
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        errors = validate(data)
+        errors = validate(data, path.resolve().parent)
     except Exception as error:
         data, errors = {}, [str(error)]
     result = {
@@ -80,7 +227,7 @@ def main() -> int:
         "intent": str(path.resolve()),
         "part": data.get("part"),
         "pass": not errors,
-        "schema": "color-intent-validation/v2",
+        "schema": "color-intent-validation/v3",
     }
     print(json.dumps(result, indent=2))
     return 0 if not errors else 1

--- a/skills/text-a3d-color/qa_check.py
+++ b/skills/text-a3d-color/qa_check.py
@@ -1,8 +1,9 @@
-"""Mesh audit tuned for one named color region of a printable assembly."""
+"""Audit color-region topology or the combined Bambu-printable assembly."""
 
 from __future__ import annotations
 
 import argparse
+from hashlib import sha256
 import json
 from pathlib import Path
 import sys
@@ -11,88 +12,577 @@ import numpy as np
 import trimesh
 
 
+class Audit:
+    def __init__(self) -> None:
+        self.checks: list[dict] = []
+
+    def add(
+        self,
+        name: str,
+        passed: bool,
+        observed,
+        expected=None,
+        *,
+        category: str = "geometry",
+        severity: str = "error",
+        repair=None,
+    ) -> None:
+        status = "pass" if passed else ("fail" if severity == "error" else "warning")
+        self.checks.append({
+            "blocking": severity == "error",
+            "category": category,
+            "name": name,
+            "observed": observed,
+            "pass": bool(passed),
+            "severity": severity,
+            "status": status,
+            **({"expected": expected} if expected is not None else {}),
+            **({"repair": repair} if repair is not None and not passed else {}),
+        })
+
+    def skip(self, name: str, reason: str, *, repair=None) -> None:
+        self.checks.append({
+            "blocking": False,
+            "category": "printability",
+            "name": name,
+            "observed": {"reason": reason},
+            "pass": False,
+            "severity": "warning",
+            "status": "not_evaluated",
+            **({"repair": repair} if repair is not None else {}),
+        })
+
+    @property
+    def passed(self) -> bool:
+        return not any(item["status"] == "fail" for item in self.checks)
+
+    @property
+    def status(self) -> str:
+        if not self.passed:
+            return "fail"
+        if any(item["status"] in {"warning", "not_evaluated"} for item in self.checks):
+            return "pass_with_warnings"
+        return "pass"
+
+
+def _load_json(path: str) -> dict:
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def _digest(path: str) -> str:
+    return sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _load_profile(path: str) -> tuple[dict, str]:
+    payload = Path(path).read_bytes()
+    profile = json.loads(payload)
+    if profile.get("schema") != "evidence-bambu-printer-profile/v1":
+        raise ValueError("unsupported printer profile schema")
+    if profile.get("vendor") != "Bambu Lab":
+        raise ValueError("only Bambu Lab printer profiles are supported")
+    required = (
+        profile.get("derived", {}).get("single_line_floor_mm"),
+        profile.get("derived", {}).get("process_wall_target_mm"),
+        profile.get("machine", {}).get("selected_tool", {}).get("height_mm"),
+        profile.get("process", {}).get("support_threshold_angle_from_horizontal_deg"),
+    )
+    if not all(isinstance(value, (int, float)) and value > 0 for value in required):
+        raise ValueError("printer profile has invalid derived limits")
+    return profile, sha256(payload).hexdigest()
+
+
+def _rectangle_bounds(polygon) -> tuple[float, float, float, float]:
+    points = np.asarray(polygon, dtype=float)
+    if points.ndim != 2 or points.shape[1] != 2 or len(points) < 4:
+        raise ValueError("printable polygons must contain at least four XY points")
+    if not np.isfinite(points).all():
+        raise ValueError("printable polygon contains non-finite coordinates")
+    lower = points.min(axis=0)
+    upper = points.max(axis=0)
+    return float(lower[0]), float(lower[1]), float(upper[0]), float(upper[1])
+
+
+def _overlaps(first, second, epsilon: float = 1e-9) -> bool:
+    return not (
+        first[2] <= second[0] + epsilon
+        or second[2] <= first[0] + epsilon
+        or first[3] <= second[1] + epsilon
+        or second[3] <= first[1] + epsilon
+    )
+
+
+def find_bed_placement(width, depth, printable_polygon, excluded_polygons):
+    container = _rectangle_bounds(printable_polygon)
+    obstacles = [_rectangle_bounds(item) for item in excluded_polygons]
+    if width > container[2] - container[0] + 1e-9:
+        return None
+    if depth > container[3] - container[1] + 1e-9:
+        return None
+    x_values = {container[0], container[2] - width}
+    y_values = {container[1], container[3] - depth}
+    for obstacle in obstacles:
+        x_values.update({obstacle[0] - width, obstacle[2]})
+        y_values.update({obstacle[1] - depth, obstacle[3]})
+    for x in sorted(x_values):
+        for y in sorted(y_values):
+            candidate = (x, y, x + width, y + depth)
+            inside = (
+                candidate[0] >= container[0] - 1e-9
+                and candidate[1] >= container[1] - 1e-9
+                and candidate[2] <= container[2] + 1e-9
+                and candidate[3] <= container[3] + 1e-9
+            )
+            if inside and not any(_overlaps(candidate, item) for item in obstacles):
+                return {
+                    "bounds_mm": [round(value, 5) for value in candidate],
+                    "origin_mm": [round(x, 5), round(y, 5)],
+                }
+    return None
+
+
+def check_bed_fit(dimensions, profile: dict) -> tuple[bool, dict]:
+    tool = profile["machine"]["selected_tool"]
+    excluded = profile["machine"].get("excluded_polygons_mm", [])
+    width, depth, height = (float(value) for value in dimensions)
+    attempts = []
+    for rotated, footprint in ((False, (width, depth)), (True, (depth, width))):
+        placement = find_bed_placement(
+            footprint[0], footprint[1], tool["polygon_mm"], excluded
+        )
+        attempts.append({
+            "footprint_mm": [round(footprint[0], 5), round(footprint[1], 5)],
+            "placement": placement,
+            "rotated_xy_90deg": rotated,
+        })
+        if placement is not None and height <= float(tool["height_mm"]) + 1e-9:
+            return True, {
+                "attempts": attempts,
+                "height_mm": round(height, 5),
+                "selected": attempts[-1],
+            }
+    return False, {"attempts": attempts, "height_mm": round(height, 5)}
+
+
+def _bbox_size(record: dict) -> list[float] | None:
+    value = record.get("bbox_mm", {}).get("size")
+    if not isinstance(value, list) or len(value) != 3:
+        return None
+    values = [float(item) for item in value]
+    return values if all(np.isfinite(values)) else None
+
+
+def feature_measurements(report: dict | None) -> list[dict]:
+    if report is None:
+        return []
+    measurements = []
+    for feature_id, record in report.get("features", {}).items():
+        size = _bbox_size(record)
+        if size is None or record.get("role") in {"body", "envelope", "parent"}:
+            continue
+        positive = [value for value in size if value > 1e-9]
+        if positive:
+            measurements.append({
+                "feature_id": feature_id,
+                "kind": record.get("role", "feature"),
+                "minimum_size_mm": min(positive),
+                "size_mm": size,
+            })
+    for event in report.get("events", []):
+        if event.get("kind") == "cut":
+            size = _bbox_size(event.get("tool", {}))
+            if size:
+                measurements.append({
+                    "feature_id": event.get("id"),
+                    "kind": "cut-tool",
+                    "minimum_size_mm": min(value for value in size if value > 1e-9),
+                    "size_mm": size,
+                })
+        elif event.get("kind") in {"fillet", "chamfer"}:
+            actual = event.get("actual_mm")
+            if isinstance(actual, (int, float)) and actual > 0:
+                measurements.append({
+                    "feature_id": event.get("id"),
+                    "kind": event["kind"],
+                    "minimum_size_mm": float(actual),
+                    "size_mm": [float(actual)],
+                })
+    return measurements
+
+
+def evidence_feature_ids(report: dict | None) -> set[str]:
+    """Return every stable feature ID backed by an observation or operation."""
+    if report is None:
+        return set()
+    identifiers = {
+        feature_id
+        for feature_id in report.get("features", {})
+        if isinstance(feature_id, str) and feature_id.strip()
+    }
+    identifiers.update(
+        event["id"]
+        for event in report.get("events", [])
+        if isinstance(event, dict)
+        and isinstance(event.get("id"), str)
+        and event["id"].strip()
+    )
+    return identifiers
+
+
+def _feature_bounds(report: dict | None) -> list[tuple[str, np.ndarray]]:
+    if report is None:
+        return []
+    records = []
+    for feature_id, record in report.get("features", {}).items():
+        bbox = record.get("bbox_mm", {})
+        if isinstance(bbox.get("min"), list) and isinstance(bbox.get("max"), list):
+            records.append((feature_id, np.asarray([bbox["min"], bbox["max"]], dtype=float)))
+    for event in report.get("events", []):
+        bbox = event.get("tool", {}).get("bbox_mm", {})
+        if isinstance(bbox.get("min"), list) and isinstance(bbox.get("max"), list):
+            records.append((event.get("id", "unnamed-cut"), np.asarray([bbox["min"], bbox["max"]], dtype=float)))
+    return records
+
+
+def _affected(bounds: np.ndarray | None, report: dict | None) -> list[str]:
+    if bounds is None:
+        return []
+    return sorted({
+        feature_id
+        for feature_id, feature_bounds in _feature_bounds(report)
+        if np.all(bounds[1] >= feature_bounds[0])
+        and np.all(feature_bounds[1] >= bounds[0])
+    })
+
+
+def thickness_observation(mesh, *, target_mm: float, sample_limit: int, report):
+    triangle_centers = np.asarray(mesh.triangles_center, dtype=float)
+    face_areas = np.asarray(mesh.area_faces, dtype=float)
+    facets = list(mesh.facets)
+    if facets:
+        centers = np.asarray([
+            np.average(triangle_centers[facet], axis=0, weights=face_areas[facet])
+            for facet in facets
+        ])
+        normals = np.asarray(mesh.facets_normal, dtype=float)
+        weights = np.asarray(mesh.facets_area, dtype=float)
+    else:
+        centers = triangle_centers
+        normals = np.asarray(mesh.face_normals, dtype=float)
+        weights = face_areas
+    if not len(centers):
+        raise ValueError("mesh has no surface regions")
+    if len(centers) > sample_limit:
+        ordered = np.argsort(weights)
+        small_count = max(1, sample_limit // 4)
+        indices = np.unique(np.concatenate((
+            ordered[:small_count], ordered[-(sample_limit - small_count):]
+        )))
+        centers, normals, weights = centers[indices], normals[indices], weights[indices]
+    values = np.asarray(
+        trimesh.proximity.thickness(mesh, centers, normals=normals, method="max_sphere"),
+        dtype=float,
+    )
+    valid = np.isfinite(values) & (values > 1e-7)
+    if not valid.any():
+        raise ValueError("local thickness produced no finite positive samples")
+    values, points, weights = values[valid], centers[valid], weights[valid]
+    violating = values < target_mm
+    risk_bounds = None
+    if violating.any():
+        risk_points = points[violating]
+        risk_bounds = np.asarray([risk_points.min(axis=0), risk_points.max(axis=0)])
+    order = np.argsort(values)
+    cumulative = np.cumsum(weights[order])
+    index = int(np.searchsorted(cumulative, cumulative[-1] * 0.05, side="left"))
+    p05 = float(values[order][min(index, len(values) - 1)])
+    return {
+        "affected_feature_ids": _affected(risk_bounds, report),
+        "minimum_mm": round(float(values.min()), 5),
+        "p05_mm": round(p05, 5),
+        "risk_bounds_mm": risk_bounds.round(5).tolist() if risk_bounds is not None else None,
+        "sample_count": int(len(values)),
+        "violating_count": int(np.count_nonzero(violating)),
+        "violating_area_ratio": round(float(weights[violating].sum() / max(weights.sum(), 1e-12)), 6),
+    }
+
+
+def overhang_observation(mesh, *, threshold_deg: float, build_plane_tolerance: float, report):
+    normals = np.asarray(mesh.face_normals, dtype=float)
+    triangles = np.asarray(mesh.triangles, dtype=float)
+    areas = np.asarray(mesh.area_faces, dtype=float)
+    minimum_z = float(mesh.bounds[0, 2])
+    above_bed = triangles[:, :, 2].max(axis=1) > minimum_z + max(build_plane_tolerance, 1e-5)
+    slopes = np.degrees(np.arccos(np.clip(np.abs(normals[:, 2]), 0.0, 1.0)))
+    risky = (normals[:, 2] < -1e-8) & above_bed & (slopes < threshold_deg)
+    if not risky.any():
+        return {
+            "affected_feature_ids": [], "area_mm2": 0.0, "face_count": 0,
+            "minimum_slope_deg": None, "risk_bounds_mm": None,
+        }
+    points = triangles[risky].reshape((-1, 3))
+    bounds = np.asarray([points.min(axis=0), points.max(axis=0)])
+    return {
+        "affected_feature_ids": _affected(bounds, report),
+        "area_mm2": round(float(areas[risky].sum()), 5),
+        "face_count": int(np.count_nonzero(risky)),
+        "minimum_slope_deg": round(float(slopes[risky].min()), 5),
+        "risk_bounds_mm": bounds.round(5).tolist(),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("stl")
-    parser.add_argument("--region", default="unnamed")
+    parser.add_argument("--region", default="combined")
+    parser.add_argument("--topology-only", action="store_true")
+    parser.add_argument("--profile")
+    parser.add_argument("--intent")
+    parser.add_argument("--report")
     parser.add_argument("--expect-x", type=float)
     parser.add_argument("--expect-y", type=float)
     parser.add_argument("--expect-z", type=float)
     parser.add_argument("--tol", type=float, default=0.5)
     parser.add_argument("--components", type=int, default=1)
-    parser.add_argument("--expect-volume", type=float)
-    parser.add_argument("--vol-tol-pct", type=float, default=10.0)
+    parser.add_argument("--require-z0", action="store_true")
+    parser.add_argument("--max-degenerate-ratio", type=float, default=0.001)
+    parser.add_argument("--thickness-samples", type=int, default=2048)
     parser.add_argument("--out")
     args = parser.parse_args()
 
     try:
-        mesh = trimesh.load(args.stl, force="mesh", process=True)
+        profile, profile_hash = _load_profile(args.profile) if args.profile else (None, None)
+        intent = _load_json(args.intent) if args.intent else None
+        report = _load_json(args.report) if args.report else None
+        if intent is not None:
+            if profile is None:
+                raise ValueError("--intent requires --profile")
+            expected_hash = intent.get("printability", {}).get("profile", {}).get("sha256")
+            if expected_hash != profile_hash:
+                raise ValueError("printer profile does not match the intent contract hash")
+        if not args.topology_only and (profile is None or intent is None or report is None):
+            raise ValueError("combined manufacturing audit requires --profile, --intent, and --report")
+        if not args.topology_only:
+            if intent.get("schema") != "evidence-color-intent/v3":
+                raise ValueError("unsupported color intent schema; expected v3")
+            if report.get("schema") != "evidence-color-build/v3":
+                raise ValueError("unsupported color build report schema; expected v3")
+            if report.get("part") != intent.get("part"):
+                raise ValueError("build report part does not match the intent contract")
+            if report.get("intent", {}).get("sha256") != _digest(args.intent):
+                raise ValueError("build report is not bound to the supplied intent")
+            combined = report.get("artifacts", {}).get("stl:combined", {})
+            if combined.get("sha256") != _digest(args.stl):
+                raise ValueError("build report is not bound to the supplied combined STL")
+            target = intent.get("printability", {}).get("minimum_wall_target_mm")
+            if not isinstance(target, (int, float)) or isinstance(target, bool) or target <= 0:
+                raise ValueError("intent minimum wall target must be positive")
+            critical = intent.get("printability", {}).get("critical_features")
+            if not isinstance(critical, list) or not critical or not all(
+                isinstance(item, str) and item.strip() for item in critical
+            ):
+                raise ValueError("intent critical features must be a non-empty list")
     except Exception as error:
-        print(json.dumps({"pass": False, "error": str(error)}))
+        print(json.dumps({"error": str(error), "pass": False}, indent=2))
         return 2
 
-    checks: list[dict] = []
+    try:
+        mesh = trimesh.load(args.stl, force="mesh", process=True)
+    except Exception as error:
+        print(json.dumps({"error": str(error), "pass": False}, indent=2))
+        return 2
+    if not isinstance(mesh, trimesh.Trimesh):
+        print(json.dumps({"error": "STL did not load as one mesh", "pass": False}, indent=2))
+        return 2
 
-    def add(name: str, passed: bool, observed, expected=None):
-        checks.append({
-            "name": name,
-            "pass": bool(passed),
-            "observed": observed,
-            **({"expected": expected} if expected is not None else {}),
-        })
-
+    audit = Audit()
     vertices = np.asarray(mesh.vertices)
     faces = np.asarray(mesh.faces)
-    add("finite_vertices", bool(np.isfinite(vertices).all()), len(vertices))
-    add("watertight", mesh.is_watertight, mesh.is_watertight, True)
-    add("consistent_winding", mesh.is_winding_consistent, mesh.is_winding_consistent, True)
-    components = len(mesh.split(only_watertight=False)) or 1
-    add("component_count", components == args.components, components, args.components)
-
+    finite = bool(len(vertices) and np.isfinite(vertices).all())
+    audit.add("finite_vertices", finite, len(vertices))
+    audit.add("has_triangles", len(faces) >= 4, len(faces), ">= 4")
+    audit.add("watertight", mesh.is_watertight, mesh.is_watertight, True)
+    audit.add("consistent_winding", mesh.is_winding_consistent, mesh.is_winding_consistent, True)
     areas = np.asarray(mesh.area_faces)
     degenerate = int(np.count_nonzero(~np.isfinite(areas) | (areas <= 1e-10)))
-    add("no_degenerate_faces", degenerate == 0, degenerate, 0)
-    volume = float(mesh.volume) if mesh.is_watertight else None
-    add("positive_volume", volume is not None and volume > 1e-6, volume, "> 0")
+    ratio = degenerate / max(len(areas), 1)
+    audit.add("degenerate_faces", ratio <= args.max_degenerate_ratio,
+              {"count": degenerate, "ratio": round(ratio, 8)},
+              {"max_ratio": args.max_degenerate_ratio})
+    components = len(mesh.split(only_watertight=False)) if len(faces) else 0
+    audit.add("connected_components", components == args.components, components, args.components)
+    volume = float(mesh.volume) if mesh.is_watertight and len(faces) else None
+    positive_volume = volume is not None and np.isfinite(volume) and volume > 1e-6
+    audit.add("positive_volume", positive_volume, volume, "> 0")
 
-    bounds = np.asarray(mesh.bounds, dtype=float)
-    dimensions = bounds[1] - bounds[0]
-    for index, axis in enumerate("xyz"):
-        expected = getattr(args, f"expect_{axis}")
-        if expected is not None:
-            add(
-                f"dimension_{axis}",
-                abs(float(dimensions[index]) - expected) <= args.tol,
-                round(float(dimensions[index]), 5),
-                {"value": expected, "tolerance": args.tol},
-            )
-    if args.expect_volume is not None and volume is not None:
-        delta = abs(volume - args.expect_volume) / max(args.expect_volume, 1e-9) * 100
-        add(
-            "volume_target", delta <= args.vol_tol_pct,
-            round(delta, 5), {"max_delta_percent": args.vol_tol_pct},
+    bounds = np.asarray(mesh.bounds, dtype=float) if finite else None
+    dims = bounds[1] - bounds[0] if bounds is not None and bounds.shape == (2, 3) else None
+    if dims is not None:
+        for index, axis in enumerate("xyz"):
+            expected = getattr(args, f"expect_{axis}")
+            if expected is not None:
+                audit.add(f"dimension_{axis}", abs(float(dims[index]) - expected) <= args.tol,
+                          round(float(dims[index]), 5),
+                          {"value": expected, "tolerance": args.tol}, category="dimensions")
+        if args.require_z0:
+            audit.add("build_plane_z0", abs(float(bounds[0, 2])) <= args.tol,
+                      round(float(bounds[0, 2]), 5),
+                      {"value": 0.0, "tolerance": args.tol}, category="dimensions")
+
+    if not args.topology_only and profile is not None and dims is not None:
+        bed_passed, bed_observed = check_bed_fit(dims, profile)
+        tool = profile["machine"]["selected_tool"]
+        audit.add("printability_bed_fit", bed_passed, bed_observed, {
+            "excluded_polygons_mm": profile["machine"].get("excluded_polygons_mm", []),
+            "printable_height_mm": tool["height_mm"],
+            "printable_polygon_mm": tool["polygon_mm"],
+        }, category="printability", repair={
+            "forbidden_actions": ["Do not switch profiles or scale fixed user dimensions to pass."],
+            "preferred_actions": ["Use the reported XY rotation or a permitted split."],
+        })
+
+        floor = float(profile["derived"]["single_line_floor_mm"])
+        target = max(
+            float(profile["derived"]["process_wall_target_mm"]),
+            float(intent["printability"]["minimum_wall_target_mm"]),
         )
+        measurements = feature_measurements(report)
+        measured_ids = {item["feature_id"] for item in measurements}
+        observed_ids = evidence_feature_ids(report)
+        critical_ids = set(intent["printability"]["critical_features"])
+        missing_critical = sorted(critical_ids - observed_ids)
+        audit.add(
+            "printability_critical_feature_coverage",
+            not missing_critical,
+            {
+                "measured_feature_ids": sorted(measured_ids),
+                "observed_feature_ids": sorted(observed_ids),
+                "missing_feature_ids": missing_critical,
+            },
+            {"critical_feature_ids": sorted(critical_ids)},
+            category="printability",
+            repair={
+                "goal": "Observe every critical feature or record its checked operation."
+            },
+        )
+        if not measurements:
+            audit.skip("printability_feature_resolution",
+                       "the v3 build report contains no measurable non-envelope features",
+                       repair="Observe manufacturing-critical features and checked cut tools.")
+        else:
+            offenders = [item for item in measurements if item["minimum_size_mm"] < floor]
+            audit.add("printability_feature_resolution", not offenders,
+                      {"examined": len(measurements), "offenders": offenders},
+                      {"minimum_single_line_mm": floor}, category="printability",
+                      severity="warning", repair={
+                          "goal": f"Increase each named feature to at least {floor:g} mm."
+                      })
+
+        if positive_volume and mesh.is_watertight:
+            try:
+                thickness = thickness_observation(
+                    mesh, target_mm=target,
+                    sample_limit=max(args.thickness_samples, 32), report=report,
+                )
+                audit.add("printability_wall_thickness",
+                          thickness["p05_mm"] + 1e-9 >= target, thickness,
+                          {"process_wall_target_mm": target,
+                           "intent_wall_target_mm": intent["printability"]["minimum_wall_target_mm"],
+                           "single_line_floor_mm": floor,
+                           "criterion": "area-weighted-p05"},
+                          category="printability", severity="warning", repair={
+                              "goal": f"Raise local wall thickness to at least {target:g} mm."
+                          })
+                audit.add(
+                    "printability_local_thin_region",
+                    thickness["violating_count"] == 0,
+                    {
+                        "affected_feature_ids": thickness["affected_feature_ids"],
+                        "minimum_mm": thickness["minimum_mm"],
+                        "risk_bounds_mm": thickness["risk_bounds_mm"],
+                        "sample_count": thickness["sample_count"],
+                        "violating_area_ratio": thickness["violating_area_ratio"],
+                        "violating_count": thickness["violating_count"],
+                    },
+                    {"minimum_local_wall_mm": target},
+                    category="printability",
+                    severity="warning",
+                    repair={
+                        "goal": f"Raise every sampled local wall to at least {target:g} mm.",
+                        "preferred_actions": [
+                            "Repair the named feature IDs intersecting the risk bounds.",
+                            "Inspect unnamed risk bounds before changing unrelated geometry.",
+                        ],
+                    },
+                )
+            except Exception as error:
+                audit.skip("printability_wall_thickness", str(error),
+                           repair="Install the pinned runtime and rerun the audit.")
+                audit.skip(
+                    "printability_local_thin_region",
+                    str(error),
+                    repair="Install the pinned runtime and rerun the audit.",
+                )
+            overhang = overhang_observation(
+                mesh,
+                threshold_deg=float(profile["process"]["support_threshold_angle_from_horizontal_deg"]),
+                build_plane_tolerance=1e-4,
+                report=report,
+            )
+            audit.add("printability_overhang", overhang["face_count"] == 0, overhang, {
+                "angle_origin": "horizontal",
+                "support_policy": intent["printability"]["support_policy"],
+                "threshold_angle_deg": profile["process"]["support_threshold_angle_from_horizontal_deg"],
+            }, category="printability", severity="warning", repair={
+                "fallback": "Declare supports-required if the geometry cannot be repaired."
+            })
+        else:
+            audit.skip(
+                "printability_wall_thickness",
+                "requires one positive watertight volume",
+            )
+            audit.skip(
+                "printability_local_thin_region",
+                "requires one positive watertight volume",
+            )
+            audit.skip(
+                "printability_overhang",
+                "requires one positive watertight volume",
+            )
 
     result = {
-        "checks": checks,
+        "checks": audit.checks,
+        "errors": [item["name"] for item in audit.checks if item["status"] == "fail"],
+        "intent": str(Path(args.intent).resolve()) if args.intent else None,
         "mesh": {
-            "bounds_mm": bounds.round(5).tolist(),
-            "dimensions_mm": dimensions.round(5).tolist(),
+            "bounds_mm": bounds.round(5).tolist() if bounds is not None else None,
+            "dimensions_mm": dims.round(5).tolist() if dims is not None else None,
             "faces": len(faces),
-            "surface_area_mm2": round(float(mesh.area), 5),
+            "surface_area_mm2": round(float(mesh.area), 5) if len(faces) else 0.0,
             "vertices": len(vertices),
             "volume_mm3": round(volume, 5) if volume is not None else None,
         },
-        "pass": all(item["pass"] for item in checks),
+        "pass": audit.passed,
+        "printer_profile": ({
+            "id": profile["id"], "path": str(Path(args.profile).resolve()),
+            "sha256": profile_hash,
+        } if profile is not None else None),
         "region": args.region,
-        "schema": "evidence-color-region-audit/v2",
+        "report": str(Path(args.report).resolve()) if args.report else None,
+        "schema": "evidence-color-mesh-audit/v3",
+        "scope": "topology" if args.topology_only else "manufacturing",
+        "status": audit.status,
         "stl": str(Path(args.stl).resolve()),
+        "warnings": [item["name"] for item in audit.checks
+                     if item["status"] in {"warning", "not_evaluated"}],
     }
     payload = json.dumps(result, indent=2)
     if args.out:
         Path(args.out).write_text(payload + "\n", encoding="utf-8")
     print(payload)
-    return 0 if result["pass"] else 1
+    return 0 if audit.passed else 1
 
 
 if __name__ == "__main__":

--- a/skills/text-a3d-color/reference_analyze.py
+++ b/skills/text-a3d-color/reference_analyze.py
@@ -43,7 +43,11 @@ def _pixel_grid(
     x, y, width, height = bbox
     crop = mask[y:y + height, x:x + width]
     scale = gcd(_run_gcd(crop), _run_gcd(crop.T))
-    if color_count > 64 or scale < 2:
+    if color_count > 64:
+        return None
+    if scale < 1:
+        scale = 1 if max(width, height) <= 64 else 0
+    if scale < 1 or (scale == 1 and max(width, height) > 64):
         return None
     grid_w = int(np.ceil(width / scale))
     grid_h = int(np.ceil(height / scale))

--- a/skills/text-a3d-color/references/bambu-printability.md
+++ b/skills/text-a3d-color/references/bambu-printability.md
@@ -1,0 +1,57 @@
+# Bambu printability for color assemblies
+
+Resolve this skill's printer profile before geometry. The profile fixes the
+machine, selected tool, nozzle, standard process, printable polygon, line-width
+floor, wall target, and support threshold for the entire evidence run.
+
+## Audit the manufacturing union
+
+Color-region meshes are semantic partitions, not independent evidence of how a
+co-printed object is supported. A downward face in one region may sit directly
+on another material. For that reason:
+
+1. Audit each region with `--topology-only` to prove its mesh and components.
+2. Pass `parent=` for every co-printed body so `export_regions()` can prove
+   coverage and export a clean `<name>-combined.stl`.
+3. Run profile-backed bed, feature, wall, and overhang checks on that combined
+   STL only.
+
+If regions are separately manufactured parts, omit `parent=` only when the
+intent records that architecture. The combined STL may then have multiple
+components; pass the reported combined `solid_count` to `--components` and
+review each part's actual print orientation separately.
+
+## Design targets
+
+- Keep every normal feature at or above `single_line_floor_mm`.
+- Use `process_wall_target_mm` for shells, internal walls, dividers, and region
+  interface walls. Meeting it proves slicer compatibility, not strength.
+- Put co-printed material interfaces on the build plane or on already printed
+  material where possible.
+- Avoid thin decorative color skins that are below one practical layer or one
+  extrusion width.
+- Treat purge reduction as secondary to appearance, region integrity, and
+  printable boundaries.
+- For internal paths, sockets, fasteners, and installed components, observe a
+  representative local clearance feature. Do not use the global bounding box
+  of a bent or compound cut tool as proof of its narrowest section.
+
+## Supports and orientation
+
+The profile's support angle is measured upward from horizontal. Prefer a
+support-free orientation for the combined assembly. Reorient, slope, chamfer,
+arch, or split the object before declaring supports required. Do not treat a
+bridge as automatically safe, and do not infer support need from an isolated
+co-printed region.
+
+## Optical materials
+
+Basic 3MF RGB assignments do not encode filament translucency, transparency,
+diffusion, or chemistry. Record optical transmission in the intent and deliver
+the generated material plan. Any non-opaque region requires an explicit slicer
+filament assignment; archive color readback alone is not an optical-material
+pass.
+
+Never switch profiles, lower limits, or scale fixed user dimensions merely to
+clear QA. At most three repair passes are allowed; unresolved warnings remain
+visible in the final status.

--- a/skills/text-a3d-color/references/bambu-profiles.json
+++ b/skills/text-a3d-color/references/bambu-profiles.json
@@ -1,0 +1,157 @@
+{
+  "schema": "amagine-bambu-profile-catalog/v1",
+  "upstream": {
+    "repository": "https://github.com/bambulab/BambuStudio",
+    "release": "v02.08.02.61",
+    "commit": "926a7192574bcb9b3a732e1ec59a46d79cb45466",
+    "vendor_config_version": "02.08.00.05"
+  },
+  "default_machine": "a1-mini",
+  "machines": {
+    "a1-mini": {
+      "name": "Bambu Lab A1 mini",
+      "bed_polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]],
+      "printable_height_mm": 180,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]], "height_mm": 180}]
+    },
+    "a1": {
+      "name": "Bambu Lab A1",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 256,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 256}]
+    },
+    "a2l": {
+      "name": "Bambu Lab A2L",
+      "bed_polygon_mm": [[0, 0], [330, 0], [330, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [330, 0], [330, 320], [0, 320]], "height_mm": 325}]
+    },
+    "p1p": {
+      "name": "Bambu Lab P1P",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "p1s": {
+      "name": "Bambu Lab P1S",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "p2s": {
+      "name": "Bambu Lab P2S",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 256,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 256}]
+    },
+    "x1": {
+      "name": "Bambu Lab X1",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "x1-carbon": {
+      "name": "Bambu Lab X1 Carbon",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "x1e": {
+      "name": "Bambu Lab X1E",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "h2s": {
+      "name": "Bambu Lab H2S",
+      "bed_polygon_mm": [[0, 0], [340, 0], [340, 320], [0, 320]],
+      "printable_height_mm": 340,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [340, 0], [340, 320], [0, 320]], "height_mm": 340}]
+    },
+    "h2d": {
+      "name": "Bambu Lab H2D",
+      "bed_polygon_mm": [[0, 0], [350, 0], [350, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [325, 0], [325, 320], [0, 320]], "height_mm": 320},
+        {"index": 1, "polygon_mm": [[25, 0], [350, 0], [350, 320], [25, 320]], "height_mm": 325}
+      ]
+    },
+    "h2d-pro": {
+      "name": "Bambu Lab H2D Pro",
+      "bed_polygon_mm": [[0, 0], [350, 0], [350, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [325, 0], [325, 320], [0, 320]], "height_mm": 320},
+        {"index": 1, "polygon_mm": [[25, 0], [350, 0], [350, 320], [25, 320]], "height_mm": 325}
+      ]
+    },
+    "h2c": {
+      "name": "Bambu Lab H2C",
+      "bed_polygon_mm": [[0, 0], [330, 0], [330, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [325, 0], [325, 320], [0, 320]], "height_mm": 320},
+        {"index": 1, "polygon_mm": [[25, 0], [330, 0], [330, 320], [25, 320]], "height_mm": 325}
+      ]
+    },
+    "x2d": {
+      "name": "Bambu Lab X2D",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 261,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 261},
+        {"index": 1, "polygon_mm": [[20.5, 0], [256, 0], [256, 256], [20.5, 256]], "height_mm": 256}
+      ]
+    }
+  },
+  "processes": {
+    "0.2": {
+      "name": "0.10mm Standard", "nozzle_diameter_mm": 0.2,
+      "layer_height_mm": 0.1, "line_width_mm": 0.22,
+      "outer_wall_line_width_mm": 0.22, "inner_wall_line_width_mm": 0.22,
+      "wall_loops": 4
+    },
+    "0.4": {
+      "name": "0.20mm Standard", "nozzle_diameter_mm": 0.4,
+      "layer_height_mm": 0.2, "line_width_mm": 0.42,
+      "outer_wall_line_width_mm": 0.42, "inner_wall_line_width_mm": 0.45,
+      "wall_loops": 2
+    },
+    "0.6": {
+      "name": "0.30mm Standard", "nozzle_diameter_mm": 0.6,
+      "layer_height_mm": 0.3, "line_width_mm": 0.62,
+      "outer_wall_line_width_mm": 0.62, "inner_wall_line_width_mm": 0.62,
+      "wall_loops": 2
+    },
+    "0.8": {
+      "name": "0.40mm Standard", "nozzle_diameter_mm": 0.8,
+      "layer_height_mm": 0.4, "line_width_mm": 0.82,
+      "outer_wall_line_width_mm": 0.82, "inner_wall_line_width_mm": 0.82,
+      "wall_loops": 2
+    }
+  },
+  "process_defaults": {
+    "wall_generator": "classic",
+    "detect_thin_wall": false,
+    "arachne_min_feature_nozzle_percent": 25,
+    "arachne_min_bead_nozzle_percent": 85,
+    "support_enabled": false,
+    "support_type": "tree(auto)",
+    "support_threshold_angle_from_horizontal_deg": 30
+  }
+}

--- a/skills/text-a3d-color/references/color-architecture.md
+++ b/skills/text-a3d-color/references/color-architecture.md
@@ -18,6 +18,9 @@ Use one of these interface patterns deliberately:
 Regions may touch at faces but may not overlap volumes. Avoid paper-thin color
 skins that disappear in slicing. For nozzle-based FDM, make visible insets at
 least one practical layer high and small strokes at least one extrusion width.
+Use the resolved profile's wall target for structural dividers and internal
+walls. For a co-printed body, keep `parent=` enabled so the manufacturing
+union is exported without internal region-interface faces.
 
 ## Palette planning
 
@@ -39,9 +42,12 @@ without recording the compromise.
 ## Closed-loop verification
 
 `export_regions()` checks region validity, overlap, optional parent coverage,
-and writes artifact hashes. `export_3mf.py` stores a shared palette and reads the
-archive XML back. `assembly_check.py` compares the expected region names/colors
-against what is actually stored in the 3MF.
+cross-checks the intent's region names/colors, exports the combined
+manufacturing STL and material plan, and writes artifact hashes.
+`export_3mf.py` stores a shared palette and reads the archive XML back.
+`assembly_check.py` compares the expected region names/colors against what is
+actually stored in the 3MF. Optical transmission remains a material-plan and
+slicer-assignment requirement because RGB readback cannot prove it.
 
 The colored four-view render is still mandatory: archive correctness cannot
 detect a geometrically misplaced color boundary.

--- a/skills/text-a3d-color/references/evidence-contract.md
+++ b/skills/text-a3d-color/references/evidence-contract.md
@@ -5,8 +5,9 @@ skill's `intent_contract.py`.
 
 ```json
 {
-  "schema": "evidence-color-intent/v2",
+  "schema": "evidence-color-intent/v3",
   "part": "product-name",
+  "task_mode": "reference-reproduction",
   "representation": "full-3d",
   "reference_files": [
     {"path": "/absolute/reference.png", "sha256": "...", "role": "appearance"}
@@ -16,20 +17,34 @@ skill's `intent_contract.py`.
     "y": {"value": 60, "source": "inferred", "confidence": "low"},
     "z": {"value": 30, "source": "reference", "confidence": "medium"}
   },
+  "features": [
+    {
+      "id": "fastener-clearance",
+      "evidence": "The assembly specification requires a through fastener.",
+      "acceptance": "Clear diameter 3.4 mm; continuous through the housing wall."
+    },
+    {
+      "id": "accent-inset",
+      "evidence": "The contrasting front insert is identity-bearing.",
+      "acceptance": "Centered inset; printable boundary and no overlap with housing."
+    }
+  ],
   "color_regions": [
     {
       "name": "housing",
       "hex": "#E8E4DC",
       "purpose": "main enclosure",
       "boundary": "complete parent shell",
-      "evidence": "warm light housing in reference"
+      "evidence": "warm light housing in reference",
+      "material": {"transmission": "opaque", "filament": "matte warm-white PLA"}
     },
     {
-      "name": "screen",
+      "name": "accent",
       "hex": "#171A1D",
-      "purpose": "identity-bearing front display",
+      "purpose": "identity-bearing front insert",
       "boundary": "front inset rectangle",
-      "evidence": "dark screen region"
+      "evidence": "dark contrasting insert region",
+      "material": {"transmission": "opaque", "filament": "matte charcoal PLA"}
     }
   ],
   "palette_reduction": {
@@ -38,10 +53,21 @@ skill's `intent_contract.py`.
     "plan": "product_palette.json",
     "deliberate_merges": ["two photographic highlights merge into housing"]
   },
+  "printability": {
+    "profile": {
+      "path": "product-name_printer-profile.json",
+      "sha256": "..."
+    },
+    "build_axis": "+Z",
+    "bed_contact": "z-min",
+    "support_policy": "support-free",
+    "minimum_wall_target_mm": 0.9,
+    "critical_features": ["fastener-clearance", "accent-inset"]
+  },
   "visual": {
     "required": true,
     "reference_view": "front",
-    "landmarks": ["screen centered", "top control distinct", "right knob distinct"]
+    "landmarks": ["accent inset centered", "top control distinct", "right knob distinct"]
   },
   "assumptions": []
 }
@@ -55,3 +81,28 @@ material boundary. Record every deliberate merge.
 The contract must distinguish permanent printed color from transient display
 content. A real LED/LCD screen is usually one physical screen region; reproduce
 individual pixels only when the user wants a static decorative face or mosaic.
+
+Every region declares `material.transmission` as `opaque`, `translucent`, or
+`transparent`. A non-opaque region must name its filament; an opaque region may
+also do so. The filament remains a manufacturing instruction rather than
+something RGB-only 3MF readback can prove. `export_regions()` cross-checks
+contract names and colors and writes a material plan that preserves these
+optical assignments.
+
+Declare functional and identity-bearing requirements independently in
+`features`. Every item needs evidence and a concrete acceptance condition.
+Every `printability.critical_features` ID must reference that list and must
+later appear as a named `observe()` record or checked operation in the v3
+build report. For routed cavities, record a representative cross-section as a
+separate named feature; the overall bounding box of a bent or compound cutting
+tool does not prove local clearance.
+
+The printability profile must come from this skill's `bambu_profile.py`. Its
+hash locks the machine, selected tool, nozzle, process, bed, feature floor,
+wall target, and support threshold. Use the combined manufacturing STL for
+printability evidence; isolated region meshes are topology evidence only.
+
+Allowed task modes are `specification`, `reference-reproduction`,
+`reference-inspired`, `recognizable-form`, and `inspect`. Matched visual views
+may be `front`, `side`, `top`, `bottom`, or `isometric`; use `bottom` when the
+appearance-bearing face is intentionally printed at Z0.

--- a/skills/text-a3d-color/render_preview.py
+++ b/skills/text-a3d-color/render_preview.py
@@ -27,6 +27,7 @@ CAMERAS = {
     "side": (0, 0),
     "top": (89.9, -90),
 }
+REFERENCE_CAMERAS = {**CAMERAS, "bottom": (-89.9, -90)}
 LIGHT = np.array([0.35, -0.55, 0.76], dtype=float)
 LIGHT /= np.linalg.norm(LIGHT)
 
@@ -136,7 +137,7 @@ def main() -> int:
     parser.add_argument("--part", action="append", required=True)
     parser.add_argument("--out", required=True)
     parser.add_argument("--size", type=int, default=900)
-    parser.add_argument("--reference-view", choices=CAMERAS)
+    parser.add_argument("--reference-view", choices=REFERENCE_CAMERAS)
     parser.add_argument("--reference-out")
     parser.add_argument("--report", help="Optional JSON evidence report")
     args = parser.parse_args()
@@ -172,7 +173,7 @@ def main() -> int:
     }
     if args.reference_view:
         matched = Path(args.reference_out)
-        _matched(regions, CAMERAS[args.reference_view], matched, args.size)
+        _matched(regions, REFERENCE_CAMERAS[args.reference_view], matched, args.size)
         result["matched_view"] = {
             "name": args.reference_view,
             "path": str(matched.resolve()),

--- a/skills/text-a3d/SKILL.md
+++ b/skills/text-a3d/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Evidence-driven single-color CAD synthesis and reconstruction. Creates fresh
   STEP/STL artifacts from specifications, drawings, or reference images using
   an independent intent contract, fail-closed build operations, provenance
-  hashes, mesh audit, and mandatory matched-view review when appearance
-  matters. Use only for single-material output or incidental photographic
+  hashes, pinned Bambu printer/nozzle/process profiles, printability repair,
+  mesh audit, and mandatory matched-view review when appearance matters. Use
+  only for single-material output or incidental photographic
   colors. If object-owned colors distinguish screens, controls, text/logos,
   materials, inlays, or identity, text-a3d-color takes priority.
 ---
@@ -22,17 +23,19 @@ session working directory.
 ## Resources
 
 - `intent_contract.py` validates independent targets before geometry
+- `bambu_profile.py` resolves pinned Bambu machine, nozzle, process, and tool limits
 - `examples/intent.example.json` is a copyable valid contract
 - `reference_analyze.py` extracts image hash, bounds, palette, and pixel cells
 - `cad_helpers.py` provides fail-closed operations and provenance-rich export
-- `qa_check.py` audits topology, finite geometry, degeneracy, dimensions, and Z0
+- `qa_check.py` audits geometry, Bambu bed fit, walls, features, and overhangs
 - `freshness_check.py` proves every deliverable belongs to this run
 - `render_preview.py` emits orthographic views plus a hash-bound render report
 - `compare_silhouette.py` scores comparable orthographic silhouettes
 - Read `references/evidence-contract.md` whenever evidence or appearance matters
 - Read `references/construction-strategies.md` before writing geometry
+- Read `references/bambu-printability.md` before every generated printable part
 
-Requires build123d, trimesh, matplotlib, Pillow, and NumPy.
+Requires build123d, trimesh, Rtree, matplotlib, Pillow, and NumPy.
 
 ## 0. Route before modeling
 
@@ -54,6 +57,19 @@ source:
 python "<SKILL_DIR>/freshness_check.py" --mark ".<name>.generation-start"
 ```
 
+Resolve one Bambu profile before the intent contract. Honor a named user or
+project printer. Otherwise use the conservative A1 mini 0.4 mm default and
+record that assumption. For dual-tool machines, select the actual tool:
+
+```bash
+python "<SKILL_DIR>/bambu_profile.py" --list
+python "<SKILL_DIR>/bambu_profile.py" --machine <machine-id> --nozzle <0.2|0.4|0.6|0.8> --tool <N> --out "<name>_printer-profile.json"
+```
+
+Read the resolver output and the generated profile. Do not model until the
+machine, tool, wall targets, and support threshold are known. Never switch the
+profile later merely to clear QA.
+
 For image evidence, run:
 
 ```bash
@@ -67,15 +83,17 @@ Write `<name>_intent.json` using
 python "<SKILL_DIR>/intent_contract.py" "<name>_intent.json"
 ```
 
-The contract must expose inferred dimensions and hidden-side assumptions. Do
-not weaken it later to match the output.
+The contract must expose inferred dimensions, hidden-side assumptions, the
+profile path and hash, build orientation, minimum wall target, critical feature
+IDs, and support policy. Do not weaken it later to match the output.
 
 ## 2. Choose construction from evidence
 
-Read `references/construction-strategies.md`. Pick full 3D, orthographic solid,
-relief, or surface-led construction deliberately. Establish axes and a feature
-dependency graph before code. Pixel/icon inputs use analyzer cells; never
-hand-copy their coordinates.
+Read `references/construction-strategies.md` and
+`references/bambu-printability.md`. Pick full 3D, orthographic solid, relief,
+or surface-led construction deliberately. Establish axes, the print
+orientation, wall parameters, and a feature dependency graph before code.
+Pixel/icon inputs use analyzer cells; never hand-copy their coordinates.
 
 ## 3. Build with observable operations
 
@@ -91,10 +109,14 @@ from cad_helpers import observe, checked_cut, checked_fillet, export_part
 NAME = "<name>"
 INTENT = "<name>_intent.json"
 
-# primary envelope -> identity volumes -> cuts -> controls -> finishes
+# primary envelope -> observed identity volumes -> cuts -> controls -> finishes
 body = ...
 observe(body, "primary-envelope", "envelope")
-body = checked_cut(body, ..., "screen-recess")
+screen = ...
+observe(screen, "screen-frame", "additive")
+body = body + screen
+screen_tool = ...
+body = checked_cut(body, screen_tool, "screen-recess")
 body = checked_fillet(
     body, lambda current: ..., 2.0, "outer-softening",
     allow_reduce=False,
@@ -104,9 +126,10 @@ if __name__ == "__main__":
     export_part(body, NAME, intent_path=INTENT)
 ```
 
-Checked operations raise instead of silently returning unchanged geometry.
-Finishing degradation is forbidden unless the contract permits it; if allowed,
-the actual size appears in the build report.
+Observe every manufacturing-critical additive feature before union. Checked
+cuts record tool bounds; checked finishes record actual size. These feature IDs
+let QA tell the model which source parameter to repair. Finishing degradation
+is forbidden unless the contract permits it.
 
 ## 4. Prove geometry, then appearance
 
@@ -114,17 +137,19 @@ Execute the source and save the mesh audit:
 
 ```bash
 python "<name>.py"
-python "<SKILL_DIR>/qa_check.py" "<name>.stl" --expect-x <X> --expect-y <Y> --expect-z <Z> --tol <T> --require-z0 --out "<name>_mesh-audit.json"
+python "<SKILL_DIR>/qa_check.py" "<name>.stl" --profile "<name>_printer-profile.json" --intent "<name>_intent.json" --report "<name>_report.json" --expect-x <X> --expect-y <Y> --expect-z <Z> --tol <T> --require-z0 --out "<name>_mesh-audit.json"
 ```
 
 Cross-check contract features against the build report's observed features and
-operation ledger. Mesh success does not prove semantic correctness.
+operation ledger. Read every `fail`, `warning`, and `not_evaluated` check plus
+its structured `repair` object. Mesh success does not prove printability or
+semantic correctness.
 
 Visual review is mandatory for reference reproduction, recognizable form, or
 any appearance requirement. Render after mesh success:
 
 ```bash
-python "<SKILL_DIR>/render_preview.py" "<name>.stl" --out "<name>_views.png" --reference-view <front|side|top|isometric> --reference-out "<name>_reference-view.png" --report "<name>_render.json"
+python "<SKILL_DIR>/render_preview.py" "<name>.stl" --out "<name>_views.png" --reference-view <front|side|top|bottom|isometric> --reference-out "<name>_reference-view.png" --report "<name>_render.json"
 ```
 
 Use `read` on the new four-view PNG and matched-view PNG. Compare every
@@ -139,10 +164,16 @@ For a truly corresponding orthographic/flat reference, also run
 - silhouette failure: change envelope/profile, not tiny details
 - depth/view failure: change representation or secondary volumes
 - mesh failure: repair topology without relaxing the contract
+- bed overflow: try reported XY rotation or orientation; preserve fixed dimensions and profile
+- feature resolution: widen the named feature parameter to the profile floor
+- thin wall: thicken the responsible shell or reduce a decorative recess
+- overhang: reorient, slope, chamfer, arch, or declare supports required
+- not evaluated: restore the missing evidence; never call it a pass
 
-After any source/build change, rerun execution, mesh audit, render, and reads.
-Maximum three evidence-repair passes. At the limit, report a failed category
-and the latest preview; never call it a match.
+Never lower a profile limit, enable slicer compensation as the only repair, or
+scale user dimensions to make QA pass. After any source/build change, rerun
+execution, mesh audit, render, and reads. Maximum three evidence-repair passes.
+At the limit, report `pass_with_warnings` or the failed category honestly.
 
 ## 6. Freshness and delivery
 
@@ -150,12 +181,17 @@ The freshness gate includes contract, source, model, reports, and required
 previews:
 
 ```bash
-python "<SKILL_DIR>/freshness_check.py" --after ".<name>.generation-start" "<name>_intent.json" "<name>.py" "<name>.step" "<name>.stl" "<name>_report.json" "<name>_mesh-audit.json" "<name>_views.png" "<name>_reference-view.png" "<name>_render.json"
+python "<SKILL_DIR>/freshness_check.py" --after ".<name>.generation-start" "<name>_printer-profile.json" "<name>_intent.json" "<name>.py" "<name>.step" "<name>.stl" "<name>_report.json" "<name>_mesh-audit.json" "<name>_views.png" "<name>_reference-view.png" "<name>_render.json"
 ```
 
 For jobs whose contract sets `visual.required` to false, omit the last three
 visual artifacts.
 
-Deliver STEP, STL, parametric source, intent contract, build report, mesh audit,
-and previews. Report specification, topology, freshness, visual fidelity, and
-printability as separate statuses.
+Deliver the resolved profile, STEP, STL, parametric source, intent contract,
+build report, mesh audit, and previews. Report specification, topology,
+freshness, visual fidelity, bed fit, feature resolution, wall thickness,
+and overhang/support need as separate statuses. Summarize the combined result
+as `print preflight passed`, `print preflight passed with warnings`, or `print
+preflight failed`. Report `actual slicer validation: not evaluated` unless a
+real Bambu Studio or equivalent slicer run was completed; never call a
+profile-backed mesh audit definitive proof that the part is printable.

--- a/skills/text-a3d/bambu_profile.py
+++ b/skills/text-a3d/bambu_profile.py
@@ -1,0 +1,147 @@
+"""Resolve a pinned Bambu machine, nozzle, process, and tool profile."""
+
+from __future__ import annotations
+
+import argparse
+from hashlib import sha256
+import json
+from pathlib import Path
+import sys
+
+
+CATALOG_PATH = Path(__file__).with_name("references") / "bambu-profiles.json"
+
+
+def load_catalog() -> dict:
+    data = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    if data.get("schema") != "amagine-bambu-profile-catalog/v1":
+        raise ValueError("unsupported Bambu profile catalog schema")
+    return data
+
+
+def resolve_machine(catalog: dict, value: str | None) -> tuple[str, dict, bool]:
+    assumed = value is None
+    requested = value or catalog["default_machine"]
+    machines = catalog["machines"]
+    normalized = requested.strip().casefold()
+    for machine_id, machine in machines.items():
+        if normalized in {machine_id.casefold(), machine["name"].casefold()}:
+            return machine_id, machine, assumed
+    available = ", ".join(sorted(machines))
+    raise ValueError(f"unknown Bambu machine {requested!r}; choose one of: {available}")
+
+
+def resolve_profile(
+    catalog: dict,
+    *,
+    machine_name: str | None,
+    nozzle: float,
+    tool_index: int,
+) -> dict:
+    machine_id, machine, assumed = resolve_machine(catalog, machine_name)
+    process_key = f"{nozzle:g}"
+    process = catalog["processes"].get(process_key)
+    if process is None:
+        available = ", ".join(sorted(catalog["processes"]))
+        raise ValueError(f"unsupported nozzle {nozzle:g} mm; choose one of: {available}")
+    tools = {int(item["index"]): item for item in machine["tools"]}
+    if tool_index not in tools:
+        available = ", ".join(str(index) for index in sorted(tools))
+        raise ValueError(
+            f"{machine['name']} has no tool {tool_index}; choose one of: {available}"
+        )
+    tool = tools[tool_index]
+    defaults = catalog["process_defaults"]
+    outer = float(process["outer_wall_line_width_mm"])
+    inner = float(process["inner_wall_line_width_mm"])
+    loops = int(process["wall_loops"])
+    return {
+        "derived": {
+            "arachne_min_bead_mm": round(
+                nozzle * defaults["arachne_min_bead_nozzle_percent"] / 100, 5
+            ),
+            "arachne_min_feature_mm": round(
+                nozzle * defaults["arachne_min_feature_nozzle_percent"] / 100, 5
+            ),
+            "process_wall_target_mm": round(outer + inner * max(loops - 1, 0), 5),
+            "single_line_floor_mm": outer,
+        },
+        "id": f"bbl-{machine_id}-{process_key}-t{tool_index}-standard",
+        "machine": {
+            "bed_polygon_mm": machine["bed_polygon_mm"],
+            "excluded_polygons_mm": machine["excluded_polygons_mm"],
+            "id": machine_id,
+            "name": machine["name"],
+            "printable_height_mm": machine["printable_height_mm"],
+            "selected_tool": tool,
+        },
+        "process": {**defaults, **process},
+        "schema": "evidence-bambu-printer-profile/v1",
+        "selection": {
+            "assumed_default_machine": assumed,
+            "tool_index": tool_index,
+        },
+        "upstream": catalog["upstream"],
+        "vendor": "Bambu Lab",
+    }
+
+
+def serialize(data: dict) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--machine", help="machine ID or official Bambu model name")
+    parser.add_argument("--nozzle", type=float, default=0.4)
+    parser.add_argument("--tool", type=int, default=0)
+    parser.add_argument("--list", action="store_true", help="list supported machines")
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    try:
+        catalog = load_catalog()
+        if args.list:
+            result = {
+                "default_machine": catalog["default_machine"],
+                "machines": [
+                    {
+                        "id": machine_id,
+                        "name": machine["name"],
+                        "tools": [item["index"] for item in machine["tools"]],
+                    }
+                    for machine_id, machine in catalog["machines"].items()
+                ],
+                "nozzles_mm": [float(value) for value in catalog["processes"]],
+                "schema": catalog["schema"],
+                "upstream": catalog["upstream"],
+            }
+            print(serialize(result), end="")
+            return 0
+        profile = resolve_profile(
+            catalog,
+            machine_name=args.machine,
+            nozzle=args.nozzle,
+            tool_index=args.tool,
+        )
+    except Exception as error:
+        print(json.dumps({"error": str(error), "pass": False}, indent=2))
+        return 2
+
+    payload = serialize(profile)
+    if args.out:
+        output = Path(args.out)
+        output.write_text(payload, encoding="utf-8")
+        artifact = {
+            "path": str(output.resolve()),
+            "profile_id": profile["id"],
+            "sha256": sha256(output.read_bytes()).hexdigest(),
+        }
+        print(json.dumps(artifact, indent=2))
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/text-a3d/cad_helpers.py
+++ b/skills/text-a3d/cad_helpers.py
@@ -62,6 +62,7 @@ def observe(shape, feature_id: str, role: str = "feature") -> None:
 def checked_cut(body, tool, feature_id: str, min_removed_mm3: float = 0.001):
     """Subtract a tool and fail if it misses or produces an invalid result."""
     before = float(body.volume)
+    tool_stats = _stats(tool)
     try:
         result = body - tool
     except Exception as error:
@@ -71,6 +72,7 @@ def checked_cut(body, tool, feature_id: str, min_removed_mm3: float = 0.001):
         "id": feature_id,
         "kind": "cut",
         "removed_mm3": round(removed, 6),
+        "tool": tool_stats,
     })
     if removed < min_removed_mm3:
         raise BuildInvariantError(

--- a/skills/text-a3d/examples/bambu-a1-mini-0.4-standard.example.json
+++ b/skills/text-a3d/examples/bambu-a1-mini-0.4-standard.example.json
@@ -1,0 +1,46 @@
+{
+  "derived": {
+    "arachne_min_bead_mm": 0.34,
+    "arachne_min_feature_mm": 0.1,
+    "process_wall_target_mm": 0.87,
+    "single_line_floor_mm": 0.42
+  },
+  "id": "bbl-a1-mini-0.4-t0-standard",
+  "machine": {
+    "bed_polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]],
+    "excluded_polygons_mm": [],
+    "id": "a1-mini",
+    "name": "Bambu Lab A1 mini",
+    "printable_height_mm": 180,
+    "selected_tool": {
+      "height_mm": 180,
+      "index": 0,
+      "polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]]
+    }
+  },
+  "process": {
+    "arachne_min_bead_nozzle_percent": 85,
+    "arachne_min_feature_nozzle_percent": 25,
+    "detect_thin_wall": false,
+    "inner_wall_line_width_mm": 0.45,
+    "layer_height_mm": 0.2,
+    "line_width_mm": 0.42,
+    "name": "0.20mm Standard",
+    "nozzle_diameter_mm": 0.4,
+    "outer_wall_line_width_mm": 0.42,
+    "support_enabled": false,
+    "support_threshold_angle_from_horizontal_deg": 30,
+    "support_type": "tree(auto)",
+    "wall_generator": "classic",
+    "wall_loops": 2
+  },
+  "schema": "evidence-bambu-printer-profile/v1",
+  "selection": {"assumed_default_machine": false, "tool_index": 0},
+  "upstream": {
+    "commit": "926a7192574bcb9b3a732e1ec59a46d79cb45466",
+    "release": "v02.08.02.61",
+    "repository": "https://github.com/bambulab/BambuStudio",
+    "vendor_config_version": "02.08.00.05"
+  },
+  "vendor": "Bambu Lab"
+}

--- a/skills/text-a3d/examples/intent.example.json
+++ b/skills/text-a3d/examples/intent.example.json
@@ -1,5 +1,5 @@
 {
-  "schema": "evidence-cad-intent/v2",
+  "schema": "evidence-cad-intent/v3",
   "part": "example-bracket",
   "task_mode": "specification",
   "representation": "full-3d",
@@ -20,6 +20,17 @@
       "acceptance": "A through-hole removes material through the full Z height."
     }
   ],
+  "printability": {
+    "profile": {
+      "path": "bambu-a1-mini-0.4-standard.example.json",
+      "sha256": "f5bdfcc78cc4e55289a4a259c6d94a6cab18534494d50655b5f0d1d67b132386"
+    },
+    "build_axis": "+Z",
+    "bed_contact": "z-min",
+    "support_policy": "support-free",
+    "minimum_wall_target_mm": 0.9,
+    "critical_features": ["mounting-hole"]
+  },
   "visual": {
     "required": false,
     "reference_view": "top",

--- a/skills/text-a3d/intent_contract.py
+++ b/skills/text-a3d/intent_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from hashlib import sha256
 from pathlib import Path
 import re
 import sys
@@ -20,10 +21,48 @@ SOURCES = {"inferred", "reference", "standard", "user"}
 CONFIDENCE = {"high", "low", "medium"}
 
 
-def validate(data: dict) -> list[str]:
+def _positive_number(value) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0
+
+
+def _load_profile(reference: dict, base_dir: Path | None, errors: list[str]) -> dict | None:
+    if not isinstance(reference, dict):
+        errors.append("printability.profile must be an object")
+        return None
+    raw_path = reference.get("path")
+    digest = reference.get("sha256")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        errors.append("printability.profile.path is required")
+        return None
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        errors.append("printability.profile.sha256 must be a lowercase SHA-256 digest")
+    if base_dir is None:
+        return None
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = base_dir / path
+    try:
+        payload = path.read_bytes()
+        profile = json.loads(payload)
+    except Exception as error:
+        errors.append(f"printability profile cannot be read: {error}")
+        return None
+    if isinstance(digest, str) and sha256(payload).hexdigest() != digest:
+        errors.append("printability profile hash does not match")
+    if profile.get("schema") != "evidence-bambu-printer-profile/v1":
+        errors.append("printability profile schema is unsupported")
+    if profile.get("vendor") != "Bambu Lab":
+        errors.append("printability profile vendor must be Bambu Lab")
+    for key in ("single_line_floor_mm", "process_wall_target_mm"):
+        if not _positive_number(profile.get("derived", {}).get(key)):
+            errors.append(f"printability profile derived.{key} must be positive")
+    return profile
+
+
+def validate(data: dict, base_dir: Path | None = None) -> list[str]:
     errors: list[str] = []
-    if data.get("schema") != "evidence-cad-intent/v2":
-        errors.append("schema must be evidence-cad-intent/v2")
+    if data.get("schema") != "evidence-cad-intent/v3":
+        errors.append("schema must be evidence-cad-intent/v3")
     if not re.fullmatch(r"[a-z0-9]+(?:[-_][a-z0-9]+)*", str(data.get("part", ""))):
         errors.append("part must be a lowercase filename-safe slug")
     if data.get("task_mode") not in MODES:
@@ -40,7 +79,7 @@ def validate(data: dict) -> list[str]:
             if not isinstance(item, dict):
                 errors.append(f"dimensions_mm.{axis} is missing")
                 continue
-            if not isinstance(item.get("value"), (int, float)) or item["value"] <= 0:
+            if not _positive_number(item.get("value")):
                 errors.append(f"dimensions_mm.{axis}.value must be positive")
             if item.get("source") not in SOURCES:
                 errors.append(f"dimensions_mm.{axis}.source must be evidence-scoped")
@@ -67,7 +106,9 @@ def validate(data: dict) -> list[str]:
     if not isinstance(visual, dict) or not isinstance(visual.get("required"), bool):
         errors.append("visual.required must be boolean")
     elif visual["required"]:
-        if visual.get("reference_view") not in {"front", "isometric", "side", "top"}:
+        if visual.get("reference_view") not in {
+            "bottom", "front", "isometric", "side", "top",
+        }:
             errors.append("visual.reference_view is required for visual validation")
         if not isinstance(visual.get("landmarks"), list) or not visual["landmarks"]:
             errors.append("visual.landmarks must be non-empty when visual is required")
@@ -76,6 +117,37 @@ def validate(data: dict) -> list[str]:
         errors.append("assumptions must be a list")
     if not isinstance(data.get("reference_files"), list):
         errors.append("reference_files must be a list")
+
+    printability = data.get("printability")
+    if not isinstance(printability, dict):
+        errors.append("printability must define a Bambu manufacturing plan")
+    else:
+        profile = _load_profile(printability.get("profile"), base_dir, errors)
+        if printability.get("build_axis") != "+Z":
+            errors.append("printability.build_axis must be +Z")
+        if printability.get("bed_contact") != "z-min":
+            errors.append("printability.bed_contact must be z-min")
+        if printability.get("support_policy") not in {
+            "support-free",
+            "supports-allowed",
+            "supports-required",
+        }:
+            errors.append("printability.support_policy is invalid")
+        target = printability.get("minimum_wall_target_mm")
+        if not _positive_number(target):
+            errors.append("printability.minimum_wall_target_mm must be positive")
+        elif profile is not None:
+            process_target = profile["derived"]["process_wall_target_mm"]
+            if target + 1e-9 < process_target:
+                errors.append(
+                    "printability.minimum_wall_target_mm must meet the selected "
+                    f"process wall target ({process_target:g} mm)"
+                )
+        critical = printability.get("critical_features")
+        if not isinstance(critical, list) or not all(
+            isinstance(item, str) and item.strip() for item in critical
+        ):
+            errors.append("printability.critical_features must be a list of feature IDs")
     return errors
 
 
@@ -86,7 +158,7 @@ def main() -> int:
     path = Path(sys.argv[1])
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        errors = validate(data)
+        errors = validate(data, path.resolve().parent)
     except Exception as error:
         errors = [str(error)]
         data = {}
@@ -95,7 +167,7 @@ def main() -> int:
         "intent": str(path.resolve()),
         "part": data.get("part"),
         "pass": not errors,
-        "schema": "intent-validation/v2",
+        "schema": "intent-validation/v3",
     }
     print(json.dumps(result, indent=2))
     return 0 if not errors else 1

--- a/skills/text-a3d/qa_check.py
+++ b/skills/text-a3d/qa_check.py
@@ -1,8 +1,9 @@
-"""Evidence-oriented mesh audit for a single exported printable solid."""
+"""Evidence-oriented mesh and Bambu FDM printability audit."""
 
 from __future__ import annotations
 
 import argparse
+from hashlib import sha256
 import json
 from pathlib import Path
 import sys
@@ -15,22 +16,349 @@ class Audit:
     def __init__(self) -> None:
         self.checks: list[dict] = []
 
-    def add(self, name: str, passed: bool, observed, expected=None) -> None:
+    def add(
+        self,
+        name: str,
+        passed: bool,
+        observed,
+        expected=None,
+        *,
+        category: str = "geometry",
+        severity: str = "error",
+        repair=None,
+    ) -> None:
+        if severity not in {"error", "warning"}:
+            raise ValueError(f"invalid audit severity: {severity}")
+        status = "pass" if passed else ("fail" if severity == "error" else "warning")
         self.checks.append({
+            "blocking": severity == "error",
+            "category": category,
             "name": name,
             "pass": bool(passed),
+            "severity": severity,
+            "status": status,
             "observed": observed,
             **({"expected": expected} if expected is not None else {}),
+            **({"repair": repair} if repair is not None and not passed else {}),
+        })
+
+    def skip(
+        self,
+        name: str,
+        reason: str,
+        *,
+        category: str = "printability",
+        repair=None,
+    ) -> None:
+        self.checks.append({
+            "blocking": False,
+            "category": category,
+            "name": name,
+            "pass": False,
+            "severity": "warning",
+            "status": "not_evaluated",
+            "observed": {"reason": reason},
+            **({"repair": repair} if repair is not None else {}),
         })
 
     @property
     def passed(self) -> bool:
-        return all(item["pass"] for item in self.checks)
+        return not any(item["status"] == "fail" for item in self.checks)
+
+    @property
+    def status(self) -> str:
+        if not self.passed:
+            return "fail"
+        if any(item["status"] in {"warning", "not_evaluated"} for item in self.checks):
+            return "pass_with_warnings"
+        return "pass"
+
+
+def _load_json(path: str) -> dict:
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def _load_profile(path: str) -> tuple[dict, str]:
+    payload = Path(path).read_bytes()
+    profile = json.loads(payload)
+    if profile.get("schema") != "evidence-bambu-printer-profile/v1":
+        raise ValueError("unsupported printer profile schema")
+    if profile.get("vendor") != "Bambu Lab":
+        raise ValueError("only Bambu Lab printer profiles are supported")
+    required = (
+        profile.get("derived", {}).get("single_line_floor_mm"),
+        profile.get("derived", {}).get("process_wall_target_mm"),
+        profile.get("machine", {}).get("selected_tool", {}).get("height_mm"),
+        profile.get("process", {}).get("support_threshold_angle_from_horizontal_deg"),
+    )
+    if not all(isinstance(value, (int, float)) and value > 0 for value in required):
+        raise ValueError("printer profile has invalid derived limits")
+    return profile, sha256(payload).hexdigest()
+
+
+def _rectangle_bounds(polygon) -> tuple[float, float, float, float]:
+    points = np.asarray(polygon, dtype=float)
+    if points.ndim != 2 or points.shape[1] != 2 or len(points) < 4:
+        raise ValueError("printable polygons must contain at least four XY points")
+    if not np.isfinite(points).all():
+        raise ValueError("printable polygon contains non-finite coordinates")
+    lower = points.min(axis=0)
+    upper = points.max(axis=0)
+    return float(lower[0]), float(lower[1]), float(upper[0]), float(upper[1])
+
+
+def _overlaps(first, second, epsilon: float = 1e-9) -> bool:
+    return not (
+        first[2] <= second[0] + epsilon
+        or second[2] <= first[0] + epsilon
+        or first[3] <= second[1] + epsilon
+        or second[3] <= first[1] + epsilon
+    )
+
+
+def find_bed_placement(
+    width: float,
+    depth: float,
+    printable_polygon,
+    excluded_polygons,
+) -> dict | None:
+    container = _rectangle_bounds(printable_polygon)
+    obstacles = [_rectangle_bounds(item) for item in excluded_polygons]
+    if width > container[2] - container[0] + 1e-9:
+        return None
+    if depth > container[3] - container[1] + 1e-9:
+        return None
+    x_values = {container[0], container[2] - width}
+    y_values = {container[1], container[3] - depth}
+    for obstacle in obstacles:
+        x_values.update({obstacle[0] - width, obstacle[2]})
+        y_values.update({obstacle[1] - depth, obstacle[3]})
+    for x in sorted(x_values):
+        for y in sorted(y_values):
+            candidate = (x, y, x + width, y + depth)
+            inside = (
+                candidate[0] >= container[0] - 1e-9
+                and candidate[1] >= container[1] - 1e-9
+                and candidate[2] <= container[2] + 1e-9
+                and candidate[3] <= container[3] + 1e-9
+            )
+            if inside and not any(_overlaps(candidate, item) for item in obstacles):
+                return {
+                    "bounds_mm": [round(value, 5) for value in candidate],
+                    "origin_mm": [round(x, 5), round(y, 5)],
+                }
+    return None
+
+
+def check_bed_fit(dimensions, profile: dict) -> tuple[bool, dict]:
+    tool = profile["machine"]["selected_tool"]
+    excluded = profile["machine"].get("excluded_polygons_mm", [])
+    width, depth, height = (float(value) for value in dimensions)
+    attempts = []
+    for rotated, footprint in ((False, (width, depth)), (True, (depth, width))):
+        placement = find_bed_placement(
+            footprint[0], footprint[1], tool["polygon_mm"], excluded
+        )
+        attempts.append({
+            "footprint_mm": [round(footprint[0], 5), round(footprint[1], 5)],
+            "placement": placement,
+            "rotated_xy_90deg": rotated,
+        })
+        if placement is not None and height <= float(tool["height_mm"]) + 1e-9:
+            return True, {
+                "attempts": attempts,
+                "height_mm": round(height, 5),
+                "selected": attempts[-1],
+            }
+    return False, {"attempts": attempts, "height_mm": round(height, 5)}
+
+
+def _bbox_size(record: dict) -> list[float] | None:
+    value = record.get("bbox_mm", {}).get("size")
+    if not isinstance(value, list) or len(value) != 3:
+        return None
+    values = [float(item) for item in value]
+    return values if all(np.isfinite(values)) else None
+
+
+def feature_measurements(report: dict | None) -> list[dict]:
+    if report is None:
+        return []
+    measurements = []
+    ignored_roles = {"body", "envelope", "parent"}
+    for feature_id, record in report.get("features", {}).items():
+        size = _bbox_size(record)
+        if size is None or record.get("role") in ignored_roles:
+            continue
+        positive = [value for value in size if value > 1e-9]
+        if positive:
+            measurements.append({
+                "feature_id": feature_id,
+                "kind": record.get("role", "feature"),
+                "minimum_size_mm": min(positive),
+                "size_mm": size,
+            })
+    for event in report.get("events", []):
+        if event.get("kind") == "cut":
+            size = _bbox_size(event.get("tool", {}))
+            if size is not None:
+                positive = [value for value in size if value > 1e-9]
+                if positive:
+                    measurements.append({
+                        "feature_id": event.get("id"),
+                        "kind": "cut-tool",
+                        "minimum_size_mm": min(positive),
+                        "size_mm": size,
+                    })
+        elif event.get("kind") in {"fillet", "chamfer"}:
+            actual = event.get("actual_mm")
+            if isinstance(actual, (int, float)) and actual > 0:
+                measurements.append({
+                    "feature_id": event.get("id"),
+                    "kind": event["kind"],
+                    "minimum_size_mm": float(actual),
+                    "size_mm": [float(actual)],
+                })
+    return measurements
+
+
+def _report_feature_bounds(report: dict | None) -> list[tuple[str, np.ndarray]]:
+    if report is None:
+        return []
+    records = []
+    for feature_id, record in report.get("features", {}).items():
+        bbox = record.get("bbox_mm", {})
+        if isinstance(bbox.get("min"), list) and isinstance(bbox.get("max"), list):
+            records.append((feature_id, np.asarray([bbox["min"], bbox["max"]], dtype=float)))
+    for event in report.get("events", []):
+        bbox = event.get("tool", {}).get("bbox_mm", {})
+        if isinstance(bbox.get("min"), list) and isinstance(bbox.get("max"), list):
+            records.append((event.get("id", "unnamed-cut"), np.asarray([bbox["min"], bbox["max"]], dtype=float)))
+    return records
+
+
+def _affected_features(bounds: np.ndarray | None, report: dict | None) -> list[str]:
+    if bounds is None:
+        return []
+    result = []
+    for feature_id, feature_bounds in _report_feature_bounds(report):
+        if np.all(bounds[1] >= feature_bounds[0]) and np.all(feature_bounds[1] >= bounds[0]):
+            result.append(feature_id)
+    return sorted(set(result))
+
+
+def thickness_observation(
+    mesh: trimesh.Trimesh,
+    *,
+    target_mm: float,
+    sample_limit: int,
+    report: dict | None,
+) -> dict:
+    triangle_centers = np.asarray(mesh.triangles_center, dtype=float)
+    face_areas = np.asarray(mesh.area_faces, dtype=float)
+    facets = list(mesh.facets)
+    if facets:
+        centers = np.asarray([
+            np.average(triangle_centers[facet], axis=0, weights=face_areas[facet])
+            for facet in facets
+        ])
+        normals = np.asarray(mesh.facets_normal, dtype=float)
+        weights = np.asarray(mesh.facets_area, dtype=float)
+    else:
+        centers = triangle_centers
+        normals = np.asarray(mesh.face_normals, dtype=float)
+        weights = face_areas
+    if not len(centers):
+        raise ValueError("mesh has no surface regions")
+    if len(centers) > sample_limit:
+        small_count = max(1, sample_limit // 4)
+        ordered = np.argsort(weights)
+        indices = np.unique(
+            np.concatenate((ordered[:small_count], ordered[-(sample_limit - small_count):]))
+        )
+        centers = centers[indices]
+        normals = normals[indices]
+        weights = weights[indices]
+    values = np.asarray(
+        trimesh.proximity.thickness(
+            mesh, centers, normals=normals, method="max_sphere"
+        ),
+        dtype=float,
+    )
+    valid = np.isfinite(values) & (values > 1e-7)
+    if not valid.any():
+        raise ValueError("local thickness produced no finite positive samples")
+    values = values[valid]
+    points = centers[valid]
+    weights = weights[valid]
+    violating = values < target_mm
+    risk_bounds = None
+    if violating.any():
+        risk_points = points[violating]
+        risk_bounds = np.asarray([risk_points.min(axis=0), risk_points.max(axis=0)])
+    order = np.argsort(values)
+    sorted_values = values[order]
+    cumulative = np.cumsum(weights[order])
+    p05_index = int(np.searchsorted(cumulative, cumulative[-1] * 0.05, side="left"))
+    p05 = float(sorted_values[min(p05_index, len(sorted_values) - 1)])
+    return {
+        "affected_feature_ids": _affected_features(risk_bounds, report),
+        "minimum_mm": round(float(values.min()), 5),
+        "p05_mm": round(p05, 5),
+        "risk_bounds_mm": risk_bounds.round(5).tolist() if risk_bounds is not None else None,
+        "sample_count": int(len(values)),
+        "violating_count": int(np.count_nonzero(violating)),
+        "violating_area_ratio": round(
+            float(weights[violating].sum() / max(weights.sum(), 1e-12)), 6
+        ),
+    }
+
+
+def overhang_observation(
+    mesh: trimesh.Trimesh,
+    *,
+    threshold_deg: float,
+    build_plane_tolerance: float,
+    report: dict | None,
+) -> dict:
+    normals = np.asarray(mesh.face_normals, dtype=float)
+    triangles = np.asarray(mesh.triangles, dtype=float)
+    areas = np.asarray(mesh.area_faces, dtype=float)
+    minimum_z = float(mesh.bounds[0, 2])
+    above_build_plane = triangles[:, :, 2].max(axis=1) > (
+        minimum_z + max(build_plane_tolerance, 1e-5)
+    )
+    downward = normals[:, 2] < -1e-8
+    slopes = np.degrees(np.arccos(np.clip(np.abs(normals[:, 2]), 0.0, 1.0)))
+    risky = downward & above_build_plane & (slopes < threshold_deg)
+    if not risky.any():
+        return {
+            "affected_feature_ids": [],
+            "area_mm2": 0.0,
+            "face_count": 0,
+            "minimum_slope_deg": None,
+            "risk_bounds_mm": None,
+        }
+    points = triangles[risky].reshape((-1, 3))
+    risk_bounds = np.asarray([points.min(axis=0), points.max(axis=0)])
+    return {
+        "affected_feature_ids": _affected_features(risk_bounds, report),
+        "area_mm2": round(float(areas[risky].sum()), 5),
+        "face_count": int(np.count_nonzero(risky)),
+        "minimum_slope_deg": round(float(slopes[risky].min()), 5),
+        "risk_bounds_mm": risk_bounds.round(5).tolist(),
+    }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("stl")
+    parser.add_argument("--profile", help="resolved profile from bambu_profile.py")
+    parser.add_argument("--intent", help="validated evidence intent contract")
+    parser.add_argument("--report", help="provenance build report from cad_helpers.py")
     parser.add_argument("--expect-x", type=float)
     parser.add_argument("--expect-y", type=float)
     parser.add_argument("--expect-z", type=float)
@@ -40,24 +368,46 @@ def main() -> int:
     parser.add_argument("--vol-tol-pct", type=float, default=10.0)
     parser.add_argument("--require-z0", action="store_true")
     parser.add_argument("--max-degenerate-ratio", type=float, default=0.001)
+    parser.add_argument("--thickness-samples", type=int, default=2048)
     parser.add_argument("--out")
     args = parser.parse_args()
+
+    try:
+        profile, profile_hash = _load_profile(args.profile) if args.profile else (None, None)
+        intent = _load_json(args.intent) if args.intent else None
+        report = _load_json(args.report) if args.report else None
+        if intent is not None:
+            if profile is None:
+                raise ValueError("--intent requires the resolved --profile")
+            expected_hash = intent.get("printability", {}).get("profile", {}).get("sha256")
+            if expected_hash != profile_hash:
+                raise ValueError("printer profile does not match the intent contract hash")
+    except Exception as error:
+        print(json.dumps({"pass": False, "error": str(error)}, indent=2))
+        return 2
 
     audit = Audit()
     try:
         mesh = trimesh.load(args.stl, force="mesh", process=True)
     except Exception as error:
-        print(json.dumps({"pass": False, "error": str(error)}))
+        print(json.dumps({"pass": False, "error": str(error)}, indent=2))
+        return 2
+
+    if not isinstance(mesh, trimesh.Trimesh):
+        print(json.dumps({"pass": False, "error": "STL did not load as one mesh"}, indent=2))
         return 2
 
     vertices = np.asarray(mesh.vertices)
     faces = np.asarray(mesh.faces)
-    audit.add("finite_vertices", bool(np.isfinite(vertices).all()), len(vertices))
+    finite_vertices = bool(len(vertices) and np.isfinite(vertices).all())
+    audit.add("finite_vertices", finite_vertices, len(vertices))
     audit.add("has_triangles", len(faces) >= 4, len(faces), ">= 4")
     audit.add("watertight", mesh.is_watertight, mesh.is_watertight, True)
     audit.add(
-        "consistent_winding", mesh.is_winding_consistent,
-        mesh.is_winding_consistent, True,
+        "consistent_winding",
+        mesh.is_winding_consistent,
+        mesh.is_winding_consistent,
+        True,
     )
 
     areas = np.asarray(mesh.area_faces)
@@ -70,29 +420,44 @@ def main() -> int:
         {"max_ratio": args.max_degenerate_ratio},
     )
 
-    components = len(mesh.split(only_watertight=False)) or 1
+    components = len(mesh.split(only_watertight=False)) if len(faces) else 0
     audit.add("connected_components", components == args.components, components, args.components)
-    volume = float(mesh.volume) if mesh.is_watertight else None
-    audit.add("positive_volume", volume is not None and volume > 1e-6, volume, "> 0")
+    volume = float(mesh.volume) if mesh.is_watertight and len(faces) else None
+    positive_volume = volume is not None and np.isfinite(volume) and volume > 1e-6
+    audit.add("positive_volume", positive_volume, volume, "> 0")
 
-    bounds = np.asarray(mesh.bounds, dtype=float)
-    dims = bounds[1] - bounds[0]
-    for index, axis in enumerate("xyz"):
-        expected = getattr(args, f"expect_{axis}")
-        if expected is not None:
+    bounds = np.asarray(mesh.bounds, dtype=float) if finite_vertices else None
+    dims = bounds[1] - bounds[0] if bounds is not None and bounds.shape == (2, 3) else None
+    if dims is not None:
+        for index, axis in enumerate("xyz"):
+            expected = getattr(args, f"expect_{axis}")
+            if expected is not None:
+                audit.add(
+                    f"dimension_{axis}",
+                    abs(float(dims[index]) - expected) <= args.tol,
+                    round(float(dims[index]), 5),
+                    {"value": expected, "tolerance": args.tol},
+                    category="dimensions",
+                )
+        if args.require_z0:
             audit.add(
-                f"dimension_{axis}",
-                abs(float(dims[index]) - expected) <= args.tol,
-                round(float(dims[index]), 5),
-                {"value": expected, "tolerance": args.tol},
+                "build_plane_z0",
+                abs(float(bounds[0, 2])) <= args.tol,
+                round(float(bounds[0, 2]), 5),
+                {"value": 0.0, "tolerance": args.tol},
+                category="dimensions",
             )
-    if args.require_z0:
+    elif args.require_z0 or any(
+        getattr(args, f"expect_{axis}") is not None for axis in "xyz"
+    ):
         audit.add(
-            "build_plane_z0",
-            abs(float(bounds[0, 2])) <= args.tol,
-            round(float(bounds[0, 2]), 5),
-            {"value": 0.0, "tolerance": args.tol},
+            "dimension_metrics_available",
+            False,
+            None,
+            "finite non-empty bounds",
+            category="dimensions",
         )
+
     if args.expect_volume is not None and volume is not None:
         delta = abs(volume - args.expect_volume) / max(args.expect_volume, 1e-9) * 100
         audit.add(
@@ -102,19 +467,227 @@ def main() -> int:
             {"value": args.expect_volume, "tolerance_percent": args.vol_tol_pct},
         )
 
+    if profile is None:
+        audit.skip(
+            "printability_profile",
+            "no resolved Bambu profile was supplied",
+            repair="Run bambu_profile.py and rerun qa_check.py with --profile.",
+        )
+    elif dims is None:
+        audit.skip("printability_bed_fit", "finite mesh bounds are unavailable")
+    else:
+        bed_passed, bed_observed = check_bed_fit(dims, profile)
+        tool = profile["machine"]["selected_tool"]
+        audit.add(
+            "printability_bed_fit",
+            bed_passed,
+            bed_observed,
+            {
+                "excluded_polygons_mm": profile["machine"].get("excluded_polygons_mm", []),
+                "printable_height_mm": tool["height_mm"],
+                "printable_polygon_mm": tool["polygon_mm"],
+            },
+            category="printability",
+            repair={
+                "forbidden_actions": [
+                    "Do not relax or switch the printer profile without user authority.",
+                    "Do not scale user-specified dimensions merely to pass the audit.",
+                ],
+                "preferred_actions": [
+                    "Try the reported 90 degree XY placement.",
+                    "Change orientation while preserving contract dimensions.",
+                    "Split the model only when the contract permits assembly.",
+                    "Ask for a larger supported Bambu machine when dimensions are fixed.",
+                ],
+            },
+        )
+
+    if profile is not None:
+        floor = float(profile["derived"]["single_line_floor_mm"])
+        target = float(profile["derived"]["process_wall_target_mm"])
+        measurements = feature_measurements(report)
+        if report is None:
+            audit.skip(
+                "printability_feature_resolution",
+                "no build report was supplied, so feature IDs cannot be measured",
+                repair="Rerun with --report <name>_report.json.",
+            )
+        elif not measurements:
+            audit.skip(
+                "printability_feature_resolution",
+                "the build report contains no measurable non-envelope features",
+                repair="Observe additive features and use checked operations for cuts and finishes.",
+            )
+        else:
+            offenders = [item for item in measurements if item["minimum_size_mm"] < floor]
+            audit.add(
+                "printability_feature_resolution",
+                not offenders,
+                {"examined": len(measurements), "offenders": offenders},
+                {"minimum_single_line_mm": floor},
+                category="printability",
+                severity="warning",
+                repair={
+                    "forbidden_actions": [
+                        "Do not enable thin-wall detection as the only repair.",
+                        "Do not lower the selected profile floor.",
+                    ],
+                    "goal": f"Increase each named feature to at least {floor:g} mm.",
+                    "preferred_actions": [
+                        "Change the parameter tied to each reported feature ID.",
+                        "Widen strokes, pins, slots, holes, chamfers, or fillets at their source.",
+                    ],
+                },
+            )
+
+        if positive_volume and mesh.is_watertight:
+            try:
+                thickness = thickness_observation(
+                    mesh,
+                    target_mm=target,
+                    sample_limit=max(args.thickness_samples, 32),
+                    report=report,
+                )
+                audit.add(
+                    "printability_wall_thickness",
+                    thickness["p05_mm"] + 1e-9 >= target,
+                    thickness,
+                    {
+                        "process_wall_target_mm": target,
+                        "single_line_floor_mm": floor,
+                        "criterion": "area-weighted-p05",
+                    },
+                    category="printability",
+                    severity="warning",
+                    repair={
+                        "forbidden_actions": [
+                            "Do not lower the wall target or rely on slicer compensation alone."
+                        ],
+                        "goal": f"Raise local wall thickness to at least {target:g} mm.",
+                        "preferred_actions": [
+                            "Increase the named wall or shell parameter.",
+                            "Thicken only the reported risk region when outer dimensions are fixed.",
+                            "Remove decorative recess depth before changing user dimensions.",
+                        ],
+                    },
+                )
+                audit.add(
+                    "printability_local_thin_region",
+                    thickness["violating_count"] == 0,
+                    {
+                        "affected_feature_ids": thickness["affected_feature_ids"],
+                        "minimum_mm": thickness["minimum_mm"],
+                        "risk_bounds_mm": thickness["risk_bounds_mm"],
+                        "sample_count": thickness["sample_count"],
+                        "violating_area_ratio": thickness["violating_area_ratio"],
+                        "violating_count": thickness["violating_count"],
+                    },
+                    {"minimum_local_wall_mm": target},
+                    category="printability",
+                    severity="warning",
+                    repair={
+                        "forbidden_actions": [
+                            "Do not dismiss a named thin region because its total area is small."
+                        ],
+                        "goal": f"Raise every sampled local wall to at least {target:g} mm.",
+                        "preferred_actions": [
+                            "Repair the named feature IDs intersecting the risk bounds.",
+                            "Inspect unnamed risk bounds before changing unrelated geometry.",
+                        ],
+                    },
+                )
+            except Exception as error:
+                audit.skip(
+                    "printability_wall_thickness",
+                    str(error),
+                    repair="Install the pinned CAD runtime and rerun the audit.",
+                )
+                audit.skip(
+                    "printability_local_thin_region",
+                    str(error),
+                    repair="Install the pinned CAD runtime and rerun the audit.",
+                )
+
+            overhang = overhang_observation(
+                mesh,
+                threshold_deg=float(
+                    profile["process"]["support_threshold_angle_from_horizontal_deg"]
+                ),
+                build_plane_tolerance=1e-4,
+                report=report,
+            )
+            audit.add(
+                "printability_overhang",
+                overhang["face_count"] == 0,
+                overhang,
+                {
+                    "angle_origin": "horizontal",
+                    "support_enabled": profile["process"]["support_enabled"],
+                    "support_policy": (
+                        intent.get("printability", {}).get("support_policy")
+                        if intent is not None
+                        else None
+                    ),
+                    "threshold_angle_deg": profile["process"][
+                        "support_threshold_angle_from_horizontal_deg"
+                    ],
+                },
+                category="printability",
+                severity="warning",
+                repair={
+                    "fallback": "Declare support_required; never claim support-free printability.",
+                    "preferred_actions": [
+                        "Reorient the build while preserving required dimensions.",
+                        "Replace the underside with a slope at or above the profile threshold.",
+                        "Use a chamfer, arch, teardrop opening, or permitted assembly split.",
+                    ],
+                },
+            )
+        else:
+            audit.skip(
+                "printability_wall_thickness",
+                "requires one positive watertight volume",
+            )
+            audit.skip(
+                "printability_local_thin_region",
+                "requires one positive watertight volume",
+            )
+            audit.skip(
+                "printability_overhang",
+                "requires one positive watertight volume",
+            )
+
     result = {
         "checks": audit.checks,
+        "errors": [item["name"] for item in audit.checks if item["status"] == "fail"],
         "mesh": {
-            "bounds_mm": bounds.round(5).tolist(),
-            "dimensions_mm": dims.round(5).tolist(),
+            "bounds_mm": bounds.round(5).tolist() if bounds is not None else None,
+            "dimensions_mm": dims.round(5).tolist() if dims is not None else None,
             "faces": len(faces),
-            "surface_area_mm2": round(float(mesh.area), 5),
+            "surface_area_mm2": round(float(mesh.area), 5) if len(faces) else 0.0,
             "vertices": len(vertices),
             "volume_mm3": round(volume, 5) if volume is not None else None,
         },
         "pass": audit.passed,
-        "schema": "evidence-mesh-audit/v2",
+        "intent": str(Path(args.intent).resolve()) if args.intent else None,
+        "printer_profile": (
+            {
+                "id": profile["id"],
+                "path": str(Path(args.profile).resolve()),
+                "sha256": profile_hash,
+            }
+            if profile is not None
+            else None
+        ),
+        "report": str(Path(args.report).resolve()) if args.report else None,
+        "schema": "evidence-mesh-audit/v3",
+        "status": audit.status,
         "stl": str(Path(args.stl).resolve()),
+        "warnings": [
+            item["name"]
+            for item in audit.checks
+            if item["status"] in {"warning", "not_evaluated"}
+        ],
     }
     payload = json.dumps(result, indent=2)
     if args.out:

--- a/skills/text-a3d/reference_analyze.py
+++ b/skills/text-a3d/reference_analyze.py
@@ -43,7 +43,11 @@ def _pixel_grid(
     x, y, width, height = bbox
     crop = mask[y:y + height, x:x + width]
     scale = gcd(_run_gcd(crop), _run_gcd(crop.T))
-    if color_count > 64 or scale < 2:
+    if color_count > 64:
+        return None
+    if scale < 1:
+        scale = 1 if max(width, height) <= 64 else 0
+    if scale < 1 or (scale == 1 and max(width, height) > 64):
         return None
     grid_w = int(np.ceil(width / scale))
     grid_h = int(np.ceil(height / scale))

--- a/skills/text-a3d/references/bambu-printability.md
+++ b/skills/text-a3d/references/bambu-printability.md
@@ -1,0 +1,64 @@
+# Bambu FDM printability
+
+Use the resolved Bambu profile as a manufacturing constraint, not as a report
+label. Preserve user dimensions and the selected profile throughout a repair
+loop.
+
+## Profile decisions
+
+- Resolve one machine, nozzle, standard process, and tool before geometry.
+- Prefer an explicit user or project selection. Otherwise use A1 mini with a
+  0.4 mm nozzle as a conservative default and record the assumption.
+- For dual-tool machines, use the selected tool's polygon and height rather
+  than the union of both tool envelopes.
+- Never switch profiles, lower limits, or scale user dimensions to clear QA.
+
+## Design targets
+
+The profile exposes two different width limits:
+
+- `single_line_floor_mm` is the smallest ordinary classic-wall line width.
+  Features below it may disappear.
+- `process_wall_target_mm` is the outer line plus the requested inner wall
+  loops. Use it as the minimum planned shell thickness.
+
+Treat load-bearing walls as a separate functional decision; meeting the
+process wall target proves slicer compatibility, not strength. Give every
+wall, pin, hole, slot, embossed stroke, recess, chamfer, and fillet a named
+parameter tied to a contract feature ID. Call `observe()` on additive feature
+solids before union. Use checked operations so subtractive tool bounds and
+finish sizes enter the build report.
+
+## Support-free construction
+
+The profile's support angle is measured up from the horizontal plane: 0
+degrees is a horizontal underside, and 90 degrees is a vertical wall. Prefer
+support-free geometry because STL and STEP do not carry a Bambu Studio support
+plan.
+
+- Reorient the build without changing required dimensions.
+- Replace shelf undersides with slopes at or above the profile threshold.
+- Use chamfers or arches under ledges and teardrop profiles for horizontal
+  holes.
+- Split the model only when the intent contract permits assembly.
+- When geometry cannot be made support-free, set `support_policy` to
+  `supports-required` and disclose the reported regions.
+
+## Repair QA evidence
+
+Read every failed or warning check and use its `repair` object. Repair the
+reported feature IDs or risk bounds, then rebuild and rerun QA.
+
+- `printability_bed_fit`: try the reported XY rotation or a permitted build
+  orientation; otherwise request a larger supported Bambu machine.
+- `printability_feature_resolution`: widen the named source feature to at
+  least `single_line_floor_mm`.
+- `printability_wall_thickness`: increase the responsible shell parameter or
+  reduce a decorative recess before changing outer dimensions.
+- `printability_overhang`: reorient, slope, chamfer, arch, or explicitly require
+  supports.
+- `not_evaluated`: restore the missing profile, report, or valid watertight
+  geometry. Never treat it as a pass.
+
+At most three evidence-repair passes are allowed. At the limit, preserve the
+latest evidence and report `pass_with_warnings` or `fail` honestly.

--- a/skills/text-a3d/references/bambu-profiles.json
+++ b/skills/text-a3d/references/bambu-profiles.json
@@ -1,0 +1,169 @@
+{
+  "schema": "amagine-bambu-profile-catalog/v1",
+  "upstream": {
+    "repository": "https://github.com/bambulab/BambuStudio",
+    "release": "v02.08.02.61",
+    "commit": "926a7192574bcb9b3a732e1ec59a46d79cb45466",
+    "vendor_config_version": "02.08.00.05"
+  },
+  "default_machine": "a1-mini",
+  "machines": {
+    "a1-mini": {
+      "name": "Bambu Lab A1 mini",
+      "bed_polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]],
+      "printable_height_mm": 180,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [180, 0], [180, 180], [0, 180]], "height_mm": 180}]
+    },
+    "a1": {
+      "name": "Bambu Lab A1",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 256,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 256}]
+    },
+    "a2l": {
+      "name": "Bambu Lab A2L",
+      "bed_polygon_mm": [[0, 0], [330, 0], [330, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [330, 0], [330, 320], [0, 320]], "height_mm": 325}]
+    },
+    "p1p": {
+      "name": "Bambu Lab P1P",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "p1s": {
+      "name": "Bambu Lab P1S",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "p2s": {
+      "name": "Bambu Lab P2S",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 256,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 256}]
+    },
+    "x1": {
+      "name": "Bambu Lab X1",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "x1-carbon": {
+      "name": "Bambu Lab X1 Carbon",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "x1e": {
+      "name": "Bambu Lab X1E",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 250,
+      "excluded_polygons_mm": [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 250}]
+    },
+    "h2s": {
+      "name": "Bambu Lab H2S",
+      "bed_polygon_mm": [[0, 0], [340, 0], [340, 320], [0, 320]],
+      "printable_height_mm": 340,
+      "excluded_polygons_mm": [],
+      "tools": [{"index": 0, "polygon_mm": [[0, 0], [340, 0], [340, 320], [0, 320]], "height_mm": 340}]
+    },
+    "h2d": {
+      "name": "Bambu Lab H2D",
+      "bed_polygon_mm": [[0, 0], [350, 0], [350, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [325, 0], [325, 320], [0, 320]], "height_mm": 320},
+        {"index": 1, "polygon_mm": [[25, 0], [350, 0], [350, 320], [25, 320]], "height_mm": 325}
+      ]
+    },
+    "h2d-pro": {
+      "name": "Bambu Lab H2D Pro",
+      "bed_polygon_mm": [[0, 0], [350, 0], [350, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [325, 0], [325, 320], [0, 320]], "height_mm": 320},
+        {"index": 1, "polygon_mm": [[25, 0], [350, 0], [350, 320], [25, 320]], "height_mm": 325}
+      ]
+    },
+    "h2c": {
+      "name": "Bambu Lab H2C",
+      "bed_polygon_mm": [[0, 0], [330, 0], [330, 320], [0, 320]],
+      "printable_height_mm": 325,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [325, 0], [325, 320], [0, 320]], "height_mm": 320},
+        {"index": 1, "polygon_mm": [[25, 0], [330, 0], [330, 320], [25, 320]], "height_mm": 325}
+      ]
+    },
+    "x2d": {
+      "name": "Bambu Lab X2D",
+      "bed_polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]],
+      "printable_height_mm": 261,
+      "excluded_polygons_mm": [],
+      "tools": [
+        {"index": 0, "polygon_mm": [[0, 0], [256, 0], [256, 256], [0, 256]], "height_mm": 261},
+        {"index": 1, "polygon_mm": [[20.5, 0], [256, 0], [256, 256], [20.5, 256]], "height_mm": 256}
+      ]
+    }
+  },
+  "processes": {
+    "0.2": {
+      "name": "0.10mm Standard",
+      "nozzle_diameter_mm": 0.2,
+      "layer_height_mm": 0.1,
+      "line_width_mm": 0.22,
+      "outer_wall_line_width_mm": 0.22,
+      "inner_wall_line_width_mm": 0.22,
+      "wall_loops": 4
+    },
+    "0.4": {
+      "name": "0.20mm Standard",
+      "nozzle_diameter_mm": 0.4,
+      "layer_height_mm": 0.2,
+      "line_width_mm": 0.42,
+      "outer_wall_line_width_mm": 0.42,
+      "inner_wall_line_width_mm": 0.45,
+      "wall_loops": 2
+    },
+    "0.6": {
+      "name": "0.30mm Standard",
+      "nozzle_diameter_mm": 0.6,
+      "layer_height_mm": 0.3,
+      "line_width_mm": 0.62,
+      "outer_wall_line_width_mm": 0.62,
+      "inner_wall_line_width_mm": 0.62,
+      "wall_loops": 2
+    },
+    "0.8": {
+      "name": "0.40mm Standard",
+      "nozzle_diameter_mm": 0.8,
+      "layer_height_mm": 0.4,
+      "line_width_mm": 0.82,
+      "outer_wall_line_width_mm": 0.82,
+      "inner_wall_line_width_mm": 0.82,
+      "wall_loops": 2
+    }
+  },
+  "process_defaults": {
+    "wall_generator": "classic",
+    "detect_thin_wall": false,
+    "arachne_min_feature_nozzle_percent": 25,
+    "arachne_min_bead_nozzle_percent": 85,
+    "support_enabled": false,
+    "support_type": "tree(auto)",
+    "support_threshold_angle_from_horizontal_deg": 30
+  }
+}

--- a/skills/text-a3d/references/evidence-contract.md
+++ b/skills/text-a3d/references/evidence-contract.md
@@ -8,7 +8,7 @@ targets merely to match a generated artifact.
 
 ```json
 {
-  "schema": "evidence-cad-intent/v2",
+  "schema": "evidence-cad-intent/v3",
   "part": "part-name",
   "task_mode": "reference-reproduction",
   "representation": "full-3d",
@@ -27,6 +27,17 @@ targets merely to match a generated artifact.
       "acceptance": "centered; width 72 ± 1 mm; depth 1.2 ± 0.2 mm"
     }
   ],
+  "printability": {
+    "profile": {
+      "path": "part-name_printer-profile.json",
+      "sha256": "..."
+    },
+    "build_axis": "+Z",
+    "bed_contact": "z-min",
+    "support_policy": "support-free",
+    "minimum_wall_target_mm": 0.9,
+    "critical_features": ["screen-recess"]
+  },
   "visual": {
     "required": true,
     "reference_view": "front",
@@ -40,6 +51,15 @@ Allowed task modes are `specification`, `reference-reproduction`,
 `reference-inspired`, `recognizable-form`, and `inspect`. Representations are
 `full-3d`, `orthographic-solid`, `relief`, and `surface-led`.
 
+The printability profile must come from this skill's `bambu_profile.py`. Its
+hash locks the machine, selected tool, nozzle, standard process, printable
+polygon, wall targets, and support threshold used for the run. The minimum
+wall target must meet the resolved process wall target. Use `support-free`
+unless supports are explicitly accepted or unavoidable.
+
+Matched visual views may be `front`, `side`, `top`, `bottom`, or `isometric`;
+use `bottom` when the appearance-bearing face is intentionally printed at Z0.
+
 ## Evidence rules
 
 - User values outrank standards, standards outrank reference measurement, and
@@ -52,6 +72,20 @@ Allowed task modes are `specification`, `reference-reproduction`,
   redraw coordinates from memory.
 - If a required target remains unknowable and changes function or identity,
   ask. Otherwise choose a reversible assumption and record it.
+
+## Printability acceptance
+
+- Empty or zero-volume geometry is a hard failure; dependent checks remain
+  `not_evaluated` rather than crashing or passing.
+- Overflow of the selected tool's printable polygon or height is a hard
+  failure. Bed exclusions and a 90-degree XY placement are considered.
+- A sub-line-width named feature is a warning tied to its feature ID.
+- Local wall thickness below the process wall target is a warning with sampled
+  risk bounds. It does not prove mechanical strength.
+- A downward surface below the Bambu process support threshold is a warning.
+  The Z0 bed face is excluded, and bridges are never assumed safe automatically.
+- A missing profile, build report, or thickness result is `not_evaluated`, not
+  a printability pass.
 
 ## Visual decision
 

--- a/skills/text-a3d/render_preview.py
+++ b/skills/text-a3d/render_preview.py
@@ -32,6 +32,7 @@ VIEWS = {
     "side": View("side", 0, 0),
     "top": View("top", 89.9, -90),
 }
+REFERENCE_VIEWS = {**VIEWS, "bottom": View("bottom", -89.9, -90)}
 LIGHT = np.array([0.35, -0.55, 0.76], dtype=float)
 LIGHT /= np.linalg.norm(LIGHT)
 
@@ -113,7 +114,7 @@ def main() -> int:
     parser.add_argument("stl")
     parser.add_argument("--out")
     parser.add_argument("--size", type=int, default=900)
-    parser.add_argument("--reference-view", choices=VIEWS)
+    parser.add_argument("--reference-view", choices=REFERENCE_VIEWS)
     parser.add_argument("--reference-out")
     parser.add_argument("--report", help="Optional JSON evidence report")
     args = parser.parse_args()
@@ -143,7 +144,7 @@ def main() -> int:
     }
     if args.reference_view:
         matched = Path(args.reference_out)
-        _save_matched(mesh, colors, VIEWS[args.reference_view], matched, args.size)
+        _save_matched(mesh, colors, REFERENCE_VIEWS[args.reference_view], matched, args.size)
         result["matched_view"] = {
             "name": args.reference_view,
             "path": str(matched.resolve()),

--- a/src/lib/licenses.ts
+++ b/src/lib/licenses.ts
@@ -102,6 +102,14 @@ export const curatedLicenses: CuratedLicense[] = [
     version: '5.0.0',
   },
   {
+    files: [{ href: '/licenses/rtree.txt', label: 'MIT' }],
+    license: 'MIT',
+    name: 'Rtree',
+    source: 'https://github.com/Toblerity/rtree/tree/1.4.1',
+    use: { en: 'Spatial index for mesh thickness queries', zh: '网格厚度查询空间索引' },
+    version: '1.4.1',
+  },
+  {
     files: [{ href: '/licenses/lib3mf.txt', label: 'BSD-2-Clause' }],
     license: 'BSD-2-Clause',
     name: 'lib3mf',

--- a/tests/python/test_skill_shared_files.py
+++ b/tests/python/test_skill_shared_files.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SINGLE = ROOT / "skills" / "text-a3d"
+COLOR = ROOT / "skills" / "text-a3d-color"
+
+
+class SharedSkillFileTests(unittest.TestCase):
+    def test_intentionally_shared_files_do_not_drift(self):
+        shared = (
+            "compare_silhouette.py",
+            "freshness_check.py",
+            "reference_analyze.py",
+        )
+        for relative in shared:
+            with self.subTest(path=relative):
+                self.assertEqual(
+                    (SINGLE / relative).read_bytes(),
+                    (COLOR / relative).read_bytes(),
+                    f"{relative} drifted between the single- and multi-color skills",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_text_a3d_color_guardrails.py
+++ b/tests/python/test_text_a3d_color_guardrails.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import contextlib
+from hashlib import sha256
+import importlib.util
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from build123d import Align, Box, Pos
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COLOR = ROOT / "skills" / "text-a3d-color"
+SINGLE = ROOT / "skills" / "text-a3d"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+color_profile = load_module("color_bambu_profile", COLOR / "bambu_profile.py")
+color_intent = load_module("color_intent_contract", COLOR / "intent_contract.py")
+single_intent = load_module("single_intent_contract", SINGLE / "intent_contract.py")
+
+
+class IndependentColorProfileTests(unittest.TestCase):
+    def test_color_skill_owns_its_profile_catalog(self):
+        self.assertEqual(color_profile.CATALOG_PATH.parent.parent, COLOR)
+        catalog = color_profile.load_catalog()
+        mini = color_profile.resolve_profile(
+            catalog, machine_name="a1-mini", nozzle=0.4, tool_index=0
+        )
+        h2d = color_profile.resolve_profile(
+            catalog, machine_name="h2d", nozzle=0.4, tool_index=1
+        )
+        self.assertEqual(mini["derived"]["process_wall_target_mm"], 0.87)
+        self.assertEqual(h2d["machine"]["selected_tool"]["height_mm"], 325)
+
+class PixelAnalyzerTests(unittest.TestCase):
+    def test_native_one_pixel_cells_are_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "native.png"
+            image = Image.new("RGBA", (5, 5), (0, 0, 0, 0))
+            image.putpixel((0, 0), (0, 255, 255, 255))
+            image.putpixel((1, 0), (0, 255, 255, 255))
+            image.putpixel((0, 1), (120, 70, 20, 255))
+            image.putpixel((1, 1), (120, 70, 20, 255))
+            image.putpixel((2, 1), (120, 70, 20, 255))
+            image.putpixel((4, 4), (0, 255, 255, 255))
+            image.save(path)
+
+            for index, skill in enumerate((SINGLE, COLOR)):
+                analyzer = load_module(
+                    f"reference_analyze_{index}", skill / "reference_analyze.py"
+                )
+                result = analyzer.analyze(path)
+                self.assertEqual(result["mode"], "pixel-art")
+                self.assertEqual(result["pixel_grid"]["cell_px"], 1)
+                self.assertEqual(len(result["pixel_grid"]["cells"]), 6)
+
+
+class ColorPipelineTests(unittest.TestCase):
+    def setUp(self):
+        if str(COLOR) not in sys.path:
+            sys.path.insert(0, str(COLOR))
+        self.cad_helpers = load_module(
+            "color_cad_helpers_test", COLOR / "cad_helpers.py"
+        )
+
+    def _build_fixture(self, root: Path) -> tuple[dict, Path, Path]:
+        self.cad_helpers._FEATURES.clear()
+        self.cad_helpers._EVENTS.clear()
+
+        left = Box(10, 10, 2, align=(Align.MIN, Align.MIN, Align.MIN))
+        right = Pos(10, 0, 0) * Box(
+            10, 10, 2, align=(Align.MIN, Align.MIN, Align.MIN)
+        )
+        parent = left + right
+        detail = Box(0.3, 2, 0.6, align=(Align.MIN, Align.MIN, Align.MIN))
+        self.cad_helpers.observe(parent, "complete-parent", "parent")
+        self.cad_helpers.observe(detail, "thin-color-detail", "additive")
+        cut_tool = Pos(9, 4, 0) * Box(
+            2, 2, 2, align=(Align.MIN, Align.MIN, Align.MIN)
+        )
+        self.cad_helpers.checked_cut(parent, cut_tool, "center-slot")
+
+        profile = color_profile.resolve_profile(
+            color_profile.load_catalog(),
+            machine_name="a1-mini",
+            nozzle=0.4,
+            tool_index=0,
+        )
+        profile_path = root / "tile_printer-profile.json"
+        profile_path.write_text(color_profile.serialize(profile), encoding="utf-8")
+        profile_hash = sha256(profile_path.read_bytes()).hexdigest()
+        intent = {
+            "schema": "evidence-color-intent/v3",
+            "part": "tile",
+            "task_mode": "specification",
+            "representation": "full-3d",
+            "reference_files": [],
+            "dimensions_mm": {
+                "x": {"value": 20, "source": "user", "confidence": "high"},
+                "y": {"value": 10, "source": "user", "confidence": "high"},
+                "z": {"value": 2, "source": "user", "confidence": "high"},
+            },
+            "features": [
+                {
+                    "id": "complete-parent",
+                    "evidence": "fixture observes the complete parent before region export",
+                    "acceptance": "the parent observation is accepted as critical build evidence",
+                },
+                {
+                    "id": "thin-color-detail",
+                    "evidence": "fixture includes a deliberately thin detail",
+                    "acceptance": "detail remains named in printability evidence",
+                },
+                {
+                    "id": "center-slot",
+                    "evidence": "fixture cuts a slot through the center",
+                    "acceptance": "2 mm cut tool intersects the parent",
+                },
+            ],
+            "color_regions": [
+                {
+                    "name": "red",
+                    "hex": "#CC2233",
+                    "purpose": "left field",
+                    "boundary": "X 0 through 10 mm",
+                    "evidence": "fixture specification",
+                    "material": {"transmission": "opaque"},
+                },
+                {
+                    "name": "blue",
+                    "hex": "#2255CC",
+                    "purpose": "right field",
+                    "boundary": "X 10 through 20 mm",
+                    "evidence": "fixture specification",
+                    "material": {
+                        "transmission": "translucent",
+                        "filament": "translucent blue PLA",
+                    },
+                },
+            ],
+            "palette_reduction": {"applied": False, "reason": "two filaments"},
+            "printability": {
+                "profile": {"path": profile_path.name, "sha256": profile_hash},
+                "build_axis": "+Z",
+                "bed_contact": "z-min",
+                "support_policy": "support-free",
+                "minimum_wall_target_mm": 0.87,
+                "critical_features": [
+                    "complete-parent",
+                    "thin-color-detail",
+                    "center-slot",
+                ],
+            },
+            "visual": {
+                "required": True,
+                "reference_view": "bottom",
+                "landmarks": ["red and blue meet at center"],
+            },
+            "assumptions": [],
+        }
+        intent_path = root / "tile_intent.json"
+        intent_path.write_text(json.dumps(intent), encoding="utf-8")
+        with contextlib.redirect_stdout(io.StringIO()):
+            report = self.cad_helpers.export_regions(
+                {"red": (left, "#CC2233"), "blue": (right, "#2255CC")},
+                "tile",
+                str(root),
+                parent=parent,
+                intent_path=str(intent_path),
+                source_path=__file__,
+            )
+        return report, profile_path, intent_path
+
+    def test_v3_report_combined_mesh_and_material_plan(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report, _, _ = self._build_fixture(root)
+            self.assertEqual(report["schema"], "evidence-color-build/v3")
+            self.assertIn("events", report)
+            self.assertIn("bbox_mm", report["features"]["thin-color-detail"])
+            self.assertIn("bbox_mm", report["events"][0]["tool"])
+            self.assertTrue((root / "tile-combined.stl").is_file())
+            plan = json.loads((root / "tile_material-plan.json").read_text())
+            self.assertTrue(plan["requires_manual_slicer_assignment"])
+            self.assertEqual(plan["archive_omits"], ["filament", "transmission"])
+
+            assembly = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLOR / "assembly_check.py"),
+                    str(root / "tile_report.json"),
+                    str(root / "tile.3mf"),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            assembly_payload = json.loads(assembly.stdout)
+            self.assertEqual(assembly.returncode, 0, assembly.stdout + assembly.stderr)
+            self.assertEqual(assembly_payload["schema"], "color-assembly-audit/v3")
+            self.assertTrue(assembly_payload["requires_manual_slicer_assignment"])
+
+    def test_manufacturing_qa_rejects_unbound_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report, profile_path, intent_path = self._build_fixture(root)
+            report_path = root / "tile_report.json"
+            base_command = [
+                sys.executable,
+                str(COLOR / "qa_check.py"),
+                str(root / "tile-combined.stl"),
+                "--profile",
+                str(profile_path),
+                "--intent",
+                str(intent_path),
+                "--report",
+                str(report_path),
+            ]
+
+            report["artifacts"]["stl:combined"]["sha256"] = "0" * 64
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+            unbound = subprocess.run(
+                base_command, check=False, capture_output=True, text=True
+            )
+            self.assertEqual(unbound.returncode, 2)
+            self.assertIn("combined STL", json.loads(unbound.stdout)["error"])
+
+    def test_every_declared_critical_feature_requires_build_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report, profile_path, intent_path = self._build_fixture(root)
+            intent = json.loads(intent_path.read_text())
+            intent["features"].append({
+                "id": "unobserved-interface-wall",
+                "evidence": "fixture declares another functional feature",
+                "acceptance": "must appear in the build evidence",
+            })
+            intent["printability"]["critical_features"].append(
+                "unobserved-interface-wall"
+            )
+            intent_path.write_text(json.dumps(intent), encoding="utf-8")
+            report["intent"]["sha256"] = sha256(intent_path.read_bytes()).hexdigest()
+            report_path = root / "tile_report.json"
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLOR / "qa_check.py"),
+                    str(root / "tile-combined.stl"),
+                    "--profile",
+                    str(profile_path),
+                    "--intent",
+                    str(intent_path),
+                    "--report",
+                    str(report_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            payload = json.loads(result.stdout)
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            coverage = next(
+                item for item in payload["checks"]
+                if item["name"] == "printability_critical_feature_coverage"
+            )
+            self.assertEqual(coverage["status"], "fail")
+            self.assertEqual(
+                coverage["observed"]["missing_feature_ids"],
+                ["unobserved-interface-wall"],
+            )
+
+    def test_region_topology_and_combined_manufacturing_are_separate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report, profile_path, intent_path = self._build_fixture(root)
+            report_path = root / "tile_report.json"
+
+            region = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLOR / "qa_check.py"),
+                    str(root / "tile-red.stl"),
+                    "--topology-only",
+                    "--region",
+                    "red",
+                    "--components",
+                    "1",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            region_payload = json.loads(region.stdout)
+            self.assertEqual(region.returncode, 0, region.stdout + region.stderr)
+            self.assertEqual(region_payload["scope"], "topology")
+            self.assertFalse(any(
+                item["category"] == "printability"
+                for item in region_payload["checks"]
+            ))
+
+            combined = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLOR / "qa_check.py"),
+                    str(root / "tile-combined.stl"),
+                    "--profile",
+                    str(profile_path),
+                    "--intent",
+                    str(intent_path),
+                    "--report",
+                    str(report_path),
+                    "--components",
+                    str(report["combined"]["solid_count"]),
+                    "--expect-x",
+                    "20",
+                    "--expect-y",
+                    "10",
+                    "--expect-z",
+                    "2",
+                    "--require-z0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            combined_payload = json.loads(combined.stdout)
+            self.assertEqual(combined.returncode, 0, combined.stdout + combined.stderr)
+            self.assertEqual(combined_payload["scope"], "manufacturing")
+            feature = next(
+                item for item in combined_payload["checks"]
+                if item["name"] == "printability_feature_resolution"
+            )
+            self.assertEqual(feature["status"], "warning")
+            self.assertEqual(
+                feature["observed"]["offenders"][0]["feature_id"],
+                "thin-color-detail",
+            )
+            coverage = next(
+                item for item in combined_payload["checks"]
+                if item["name"] == "printability_critical_feature_coverage"
+            )
+            self.assertEqual(coverage["status"], "pass")
+            self.assertIn(
+                "complete-parent", coverage["observed"]["observed_feature_ids"]
+            )
+            self.assertNotIn(
+                "complete-parent", coverage["observed"]["measured_feature_ids"]
+            )
+
+    def test_bottom_matched_view_is_available(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._build_fixture(root)
+            report_path = root / "render.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLOR / "render_preview.py"),
+                    "--part",
+                    f"{root / 'tile-red.stl'}=#CC2233",
+                    "--part",
+                    f"{root / 'tile-blue.stl'}=#2255CC",
+                    "--out",
+                    str(root / "views.png"),
+                    "--reference-view",
+                    "bottom",
+                    "--reference-out",
+                    str(root / "bottom.png"),
+                    "--report",
+                    str(report_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            render = json.loads(report_path.read_text())
+            self.assertEqual(render["matched_view"]["name"], "bottom")
+            self.assertTrue((root / "bottom.png").is_file())
+
+
+class ColorContractTests(unittest.TestCase):
+    def test_checked_in_v3_example_is_valid(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(COLOR / "intent_contract.py"),
+                str(COLOR / "examples" / "intent.example.json"),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(json.loads(result.stdout)["pass"])
+
+    def test_non_opaque_regions_require_a_filament_assignment(self):
+        example_path = COLOR / "examples" / "intent.example.json"
+        data = json.loads(example_path.read_text())
+        data["color_regions"][1]["material"] = {"transmission": "translucent"}
+        errors = color_intent.validate(data, example_path.parent)
+        self.assertTrue(any("filament is required" in item for item in errors))
+
+    def test_single_color_contract_accepts_bottom_matched_view(self):
+        example_path = SINGLE / "examples" / "intent.example.json"
+        data = json.loads(example_path.read_text())
+        data["visual"] = {
+            "required": True,
+            "reference_view": "bottom",
+            "landmarks": ["appearance-bearing face at Z0"],
+        }
+        self.assertEqual(single_intent.validate(data, example_path.parent), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_text_a3d_printability.py
+++ b/tests/python/test_text_a3d_printability.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+import trimesh
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / "skills" / "text-a3d"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+bambu_profile = load_module("bambu_profile", SKILL / "bambu_profile.py")
+qa_check = load_module("qa_check", SKILL / "qa_check.py")
+
+
+class BambuProfileTests(unittest.TestCase):
+    def test_resolves_single_and_dual_tool_limits(self):
+        catalog = bambu_profile.load_catalog()
+        mini = bambu_profile.resolve_profile(
+            catalog, machine_name="a1-mini", nozzle=0.4, tool_index=0
+        )
+        self.assertEqual(mini["machine"]["selected_tool"]["height_mm"], 180)
+        self.assertEqual(mini["derived"]["process_wall_target_mm"], 0.87)
+
+        h2d = bambu_profile.resolve_profile(
+            catalog, machine_name="Bambu Lab H2D", nozzle=0.4, tool_index=1
+        )
+        polygon = np.asarray(h2d["machine"]["selected_tool"]["polygon_mm"])
+        self.assertEqual(float(np.ptp(polygon[:, 0])), 325.0)
+        self.assertEqual(h2d["machine"]["selected_tool"]["height_mm"], 325)
+
+    def test_default_is_explicitly_marked_as_assumed(self):
+        profile = bambu_profile.resolve_profile(
+            bambu_profile.load_catalog(), machine_name=None, nozzle=0.4, tool_index=0
+        )
+        self.assertEqual(profile["machine"]["id"], "a1-mini")
+        self.assertTrue(profile["selection"]["assumed_default_machine"])
+
+
+class PrintabilityGeometryTests(unittest.TestCase):
+    def setUp(self):
+        self.catalog = bambu_profile.load_catalog()
+
+    def test_bed_fit_allows_xy_rotation_and_rejects_overflow(self):
+        h2s = bambu_profile.resolve_profile(
+            self.catalog, machine_name="h2s", nozzle=0.4, tool_index=0
+        )
+        passed, observed = qa_check.check_bed_fit([310, 330, 20], h2s)
+        self.assertTrue(passed)
+        self.assertTrue(observed["selected"]["rotated_xy_90deg"])
+
+        mini = bambu_profile.resolve_profile(
+            self.catalog, machine_name="a1-mini", nozzle=0.4, tool_index=0
+        )
+        passed, _ = qa_check.check_bed_fit([181, 170, 20], mini)
+        self.assertFalse(passed)
+
+    def test_excluded_bed_area_can_be_avoided_by_placement(self):
+        placement = qa_check.find_bed_placement(
+            250,
+            250,
+            [[0, 0], [256, 0], [256, 256], [0, 256]],
+            [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+        )
+        self.assertIsNone(placement)
+        placement = qa_check.find_bed_placement(
+            220,
+            220,
+            [[0, 0], [256, 0], [256, 256], [0, 256]],
+            [[[0, 0], [18, 0], [18, 28], [0, 28]]],
+        )
+        self.assertIsNotNone(placement)
+
+    def test_wall_thickness_sampling_detects_thin_plate(self):
+        mesh = trimesh.creation.box(extents=[10, 10, 0.5])
+        mesh.apply_translation([0, 0, 0.25])
+        observed = qa_check.thickness_observation(
+            mesh, target_mm=0.87, sample_limit=128, report=None
+        )
+        self.assertLess(observed["p05_mm"], 0.87)
+        self.assertAlmostEqual(observed["minimum_mm"], 0.5, places=4)
+
+    def test_local_thin_region_is_not_hidden_by_area_weighted_p05(self):
+        profile = bambu_profile.resolve_profile(
+            self.catalog, machine_name="a1-mini", nozzle=0.4, tool_index=0
+        )
+        base = trimesh.creation.box(extents=[40, 24, 1.0])
+        base.apply_translation([0, 0, 0.5])
+        local_wall = trimesh.creation.box(extents=[20, 0.6, 0.6])
+        local_wall.apply_translation([0, 0, 1.3])
+        mesh = trimesh.util.concatenate([base, local_wall])
+        report = {
+            "events": [],
+            "features": {
+                "local-wall": {
+                    "role": "wall",
+                    "bbox_mm": {
+                        "min": [-10, -0.3, 1.0],
+                        "max": [10, 0.3, 1.6],
+                        "size": [20, 0.6, 0.6],
+                    },
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            profile_path = root / "profile.json"
+            report_path = root / "report.json"
+            mesh_path = root / "local-thin.stl"
+            profile_path.write_text(bambu_profile.serialize(profile), encoding="utf-8")
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+            mesh.export(mesh_path)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL / "qa_check.py"),
+                    str(mesh_path),
+                    "--profile",
+                    str(profile_path),
+                    "--report",
+                    str(report_path),
+                    "--components",
+                    "2",
+                    "--require-z0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            payload = json.loads(result.stdout)
+            p05 = next(
+                item for item in payload["checks"]
+                if item["name"] == "printability_wall_thickness"
+            )
+            local = next(
+                item for item in payload["checks"]
+                if item["name"] == "printability_local_thin_region"
+            )
+            feature = next(
+                item for item in payload["checks"]
+                if item["name"] == "printability_feature_resolution"
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(p05["status"], "pass")
+            self.assertEqual(feature["status"], "pass")
+            self.assertEqual(local["status"], "warning")
+            self.assertEqual(local["observed"]["affected_feature_ids"], ["local-wall"])
+            self.assertIn("printability_local_thin_region", payload["warnings"])
+
+    def test_overhang_ignores_bed_face_and_finds_elevated_ceiling(self):
+        base = trimesh.creation.box(extents=[10, 10, 2])
+        base.apply_translation([0, 0, 1])
+        safe = qa_check.overhang_observation(
+            base, threshold_deg=30, build_plane_tolerance=0.5, report=None
+        )
+        self.assertEqual(safe["face_count"], 0)
+
+        shelf = trimesh.creation.box(extents=[8, 8, 1])
+        shelf.apply_translation([0, 0, 5.5])
+        combined = trimesh.util.concatenate([base, shelf])
+        risky = qa_check.overhang_observation(
+            combined, threshold_deg=30, build_plane_tolerance=0.5, report=None
+        )
+        self.assertGreater(risky["face_count"], 0)
+        self.assertEqual(risky["minimum_slope_deg"], 0.0)
+
+    def test_feature_measurements_use_named_build_evidence(self):
+        report = {
+            "features": {
+                "primary": {
+                    "role": "envelope",
+                    "bbox_mm": {"size": [40, 24, 8]},
+                },
+                "thin-logo": {
+                    "role": "additive",
+                    "bbox_mm": {"size": [8, 0.3, 0.6]},
+                },
+            },
+            "events": [
+                {
+                    "id": "small-hole",
+                    "kind": "cut",
+                    "tool": {"bbox_mm": {"size": [0.35, 0.35, 10]}},
+                }
+            ],
+        }
+        measured = qa_check.feature_measurements(report)
+        self.assertEqual(
+            {item["feature_id"] for item in measured}, {"thin-logo", "small-hole"}
+        )
+        self.assertEqual(min(item["minimum_size_mm"] for item in measured), 0.3)
+
+    def test_cli_keeps_warnings_non_blocking_and_bed_overflow_blocking(self):
+        profile = bambu_profile.resolve_profile(
+            self.catalog, machine_name="a1-mini", nozzle=0.4, tool_index=0
+        )
+        report = {
+            "events": [],
+            "features": {
+                "plate": {
+                    "role": "additive",
+                    "bbox_mm": {"min": [0, 0, 0], "max": [40, 24, 0.5], "size": [40, 24, 0.5]},
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            profile_path = root / "profile.json"
+            report_path = root / "report.json"
+            thin_path = root / "thin.stl"
+            large_path = root / "large.stl"
+            profile_path.write_text(bambu_profile.serialize(profile), encoding="utf-8")
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            thin = trimesh.creation.box(extents=[40, 24, 0.5])
+            thin.apply_translation([0, 0, 0.25])
+            thin.export(thin_path)
+            warning_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL / "qa_check.py"),
+                    str(thin_path),
+                    "--profile",
+                    str(profile_path),
+                    "--report",
+                    str(report_path),
+                    "--require-z0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            warning_payload = json.loads(warning_result.stdout)
+            self.assertEqual(warning_result.returncode, 0)
+            self.assertEqual(warning_payload["status"], "pass_with_warnings")
+            self.assertIn("printability_wall_thickness", warning_payload["warnings"])
+
+            large = trimesh.creation.box(extents=[181, 20, 8])
+            large.apply_translation([0, 0, 4])
+            large.export(large_path)
+            fail_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL / "qa_check.py"),
+                    str(large_path),
+                    "--profile",
+                    str(profile_path),
+                    "--report",
+                    str(report_path),
+                    "--require-z0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            fail_payload = json.loads(fail_result.stdout)
+            self.assertEqual(fail_result.returncode, 1)
+            self.assertIn("printability_bed_fit", fail_payload["errors"])
+
+
+class ContractTests(unittest.TestCase):
+    def test_checked_in_example_contract_is_valid(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SKILL / "intent_contract.py"),
+                str(SKILL / "examples" / "intent.example.json"),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(json.loads(result.stdout)["pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add pinned Bambu printer, nozzle, process, and tool profiles to both CAD skills
- bind printability expectations and critical feature IDs to the intent contracts
- add bed-fit failures plus wall-thickness, local thin-region, feature-resolution, and overhang checks with structured repair evidence
- audit the combined manufacturing mesh for multi-color parts and preserve material/transmission assignment evidence
- add the Rtree runtime dependency, local Python regression coverage, and CI execution

## Validation

- `npm run licenses:check`
- `npm run typecheck`
- `npm test` — 45 tests passed
- `npm run test:python` — 21 tests passed
- both Skill folders passed `quick_validate.py`

## Validation note

This implementation performs well against the local test suite. Its effectiveness in specific real-world modeling and printing scenarios still needs community validation, feedback, and further optimization.

Closes #4