### PR TITLE
feat(render): add CPU z-buffer previews

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Hash-bound JSON evidence must have stable bytes on every checkout platform.
+*.json text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,31 @@ jobs:
       - run: npm run test:python
       - run: npm run build
       - run: npm audit --audit-level=high
+
+  cpu-renderer:
+    name: CPU renderer (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    env:
+      MKL_NUM_THREADS: '1'
+      NUMEXPR_NUM_THREADS: '1'
+      OMP_NUM_THREADS: '1'
+      OPENBLAS_NUM_THREADS: '1'
+      VECLIB_MAXIMUM_THREADS: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - run: python -m pip install --disable-pip-version-check --requirement requirements.txt
+      - run: python -m unittest discover -s tests/python -p "test_*.py"
+      - run: python scripts/benchmark_cpu_z_buffer.py --resolution 320 --large-subdivisions 4 --out cpu-z-buffer-benchmark.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cpu-z-buffer-benchmark-${{ matrix.os }}
+          path: cpu-z-buffer-benchmark.json

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,8 +9,17 @@ npm ci
 npm run python:setup
 npm run typecheck
 npm test
+npm run test:python
 npm run build
 ```
+
+The PNG evidence renderer is a headless CPU Z-buffer implemented with trimesh,
+NumPy, and Pillow. It renders four views sequentially in one process. Use
+`npm run benchmark:renderer` to record small, medium, and larger
+STL timings, peak memory, and triangle counts. The renderer defaults to 1x;
+the four-view output is 640 pixels, and 2x supersampling is opt-in. Its
+`pathlib`-based, single-process path is covered
+on Ubuntu and Windows in CI and uses the same headless code on macOS.
 
 Keep browser code behind the local API boundary. React must not access model
 credentials, Agent session JSONL files, uploads, or session workspaces

--- a/docs/CONTRIBUTING.zh-CN.md
+++ b/docs/CONTRIBUTING.zh-CN.md
@@ -9,8 +9,16 @@ npm ci
 npm run python:setup
 npm run typecheck
 npm test
+npm run test:python
 npm run build
 ```
+
+PNG 证据图使用由 trimesh、NumPy 和 Pillow 实现的无界面 CPU Z-buffer。
+四个视图默认在单进程内串行渲染。运行
+`npm run benchmark:renderer` 可记录小型、中型和较大 STL 的
+耗时、峰值内存与三角形数量。四视图默认输出 640 像素并使用 1×，2× 超采样需显式开启。
+这条基于 `pathlib` 的单进程链路在 CI 中覆盖 Ubuntu 和 Windows，macOS
+使用相同的无界面代码路径。
 
 请保持浏览器代码与本地 API 之间的边界。React 不得直接访问模型凭据、
 Agent session JSONL、上传目录或 session 工作区。服务端产物路由必须把所有路径

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc --noEmit && vite build",
+    "benchmark:renderer": "node scripts/run-project-python.mjs scripts/benchmark_cpu_z_buffer.py",
     "dev": "npm run python:setup && concurrently -k -n api,web -c blue,white \"tsx watch server/index.ts\" \"vite\"",
     "doctor": "tsx server/doctor.ts",
     "licenses:check": "node scripts/check-licenses.mjs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Pinned top-level CAD runtime. Transitive wheels are resolved for the host OS.
 build123d==0.11.1
 lib3mf==2.5.0
-matplotlib==3.10.9
 numpy==2.2.6
 pillow==12.3.0
 rtree==1.4.1

--- a/scripts/benchmark_cpu_z_buffer.py
+++ b/scripts/benchmark_cpu_z_buffer.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Benchmark small, medium, and larger STL inputs on the CPU renderer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import tempfile
+import time
+import tracemalloc
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_ROOT = ROOT / "skills"
+if str(SKILLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SKILLS_ROOT))
+
+from cpu_z_buffer import (  # noqa: E402
+    DEFAULT_MATERIAL,
+    MeshInput,
+    RenderLimits,
+    load_mesh,
+    render_contact_sheet,
+    render_view,
+)
+import trimesh  # noqa: E402
+
+
+def _models(large_subdivisions: int) -> dict[str, trimesh.Trimesh]:
+    return {
+        "small": trimesh.creation.box(extents=(4.0, 3.0, 2.0)),
+        "medium": trimesh.creation.icosphere(subdivisions=3, radius=2.0),
+        "large": trimesh.creation.icosphere(
+            subdivisions=large_subdivisions, radius=2.0
+        ),
+    }
+
+
+def _benchmark(path: Path, resolution: int, limits: RenderLimits) -> dict[str, object]:
+    tracemalloc.reset_peak()
+    loaded = load_mesh(path)
+    inputs = [MeshInput(path.stem, loaded, DEFAULT_MATERIAL, path)]
+
+    single_started = time.perf_counter()
+    single = render_view(inputs, "isometric", resolution, limits=limits)
+    single_seconds = time.perf_counter() - single_started
+
+    four = render_contact_sheet(
+        inputs,
+        resolution,
+        title=path.stem,
+        limits=limits,
+    )
+    _, traced_peak = tracemalloc.get_traced_memory()
+    return {
+        "four_view_seconds": round(four.elapsed_seconds, 6),
+        "peak_memory_bytes": max(
+            int(traced_peak), single.stats.buffer_bytes, four.peak_buffer_bytes
+        ),
+        "single_view_seconds": round(single_seconds, 6),
+        "triangle_count": len(loaded.faces),
+        "views": {stat.view: stat.to_dict() for stat in four.stats},
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--resolution", type=int, default=480)
+    parser.add_argument("--large-subdivisions", type=int, default=5)
+    parser.add_argument("--out")
+    args = parser.parse_args()
+    if args.resolution < 320:
+        parser.error("--resolution must be at least 320")
+    if args.large_subdivisions < 4 or args.large_subdivisions > 6:
+        parser.error("--large-subdivisions must be between 4 and 6")
+
+    limits = RenderLimits()
+    results: dict[str, object] = {
+        "default_parallel_views": False,
+        "default_processes": 1,
+        "resolution": args.resolution,
+        "renderer": "cpu-z-buffer/v1",
+        "supersample": 1,
+        "workloads": {},
+    }
+    tracemalloc.start()
+    with tempfile.TemporaryDirectory(prefix="amagine-cpu-render-") as temporary:
+        temporary_root = Path(temporary)
+        for name, mesh in _models(args.large_subdivisions).items():
+            path = temporary_root / f"{name}.stl"
+            mesh.export(path)
+            results["workloads"][name] = _benchmark(path, args.resolution, limits)
+    tracemalloc.stop()
+
+    payload = json.dumps(results, indent=2)
+    if args.out:
+        destination = Path(args.out).resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-project-python.mjs
+++ b/scripts/run-project-python.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptDirectory, '..');
+const executable = process.platform === 'win32'
+  ? join(projectRoot, '.venv', 'Scripts', 'python.exe')
+  : join(projectRoot, '.venv', 'bin', 'python');
+
+if (!existsSync(executable)) {
+  console.error('Project Python is not ready. Run npm run python:setup first.');
+  process.exit(1);
+}
+
+const result = spawnSync(executable, process.argv.slice(2), {
+  cwd: projectRoot,
+  stdio: 'inherit',
+});
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/scripts/setup-python.mjs
+++ b/scripts/setup-python.mjs
@@ -108,7 +108,7 @@ const venvPython = environmentPython();
 if (currentMarker === fingerprint && existsSync(venvPython)) {
   const check = run(
     venvPython,
-    ['-c', 'import build123d, lib3mf, matplotlib, numpy, PIL, rtree, trimesh'],
+    ['-c', 'import build123d, lib3mf, numpy, PIL, rtree, trimesh'],
     { capture: true },
   );
   if (check.status === 0) {
@@ -150,7 +150,7 @@ if (installed.status !== 0) {
 
 const verified = run(
   venvPython,
-  ['-c', 'import build123d, lib3mf, matplotlib, numpy, PIL, rtree, trimesh'],
+  ['-c', 'import build123d, lib3mf, numpy, PIL, rtree, trimesh'],
   { capture: true },
 );
 if (verified.status !== 0) {

--- a/server/python-runtime.ts
+++ b/server/python-runtime.ts
@@ -21,13 +21,12 @@ export function activateProjectPython(projectRoot: string): PythonHealth {
     : join(projectRoot, '.venv', 'bin');
   process.env.VIRTUAL_ENV = join(projectRoot, '.venv');
   process.env.PATH = `${environmentBin}${delimiter}${process.env.PATH ?? ''}`;
-  process.env.MPLBACKEND = 'Agg';
 
   const result = spawnSync(
     executable,
     [
       '-c',
-      'import platform, build123d, lib3mf, matplotlib, numpy, PIL, rtree, trimesh; print(platform.python_version())',
+      'import platform, build123d, lib3mf, numpy, PIL, rtree, trimesh; print(platform.python_version())',
     ],
     { encoding: 'utf8' },
   );

--- a/skills/cpu_z_buffer.py
+++ b/skills/cpu_z_buffer.py
@@ -1,0 +1,656 @@
+"""Headless orthographic rendering with a bounded, single-process CPU Z-buffer.
+
+trimesh owns mesh I/O and geometry data, NumPy owns projection and triangle
+coverage, and Pillow owns image output.  The module deliberately has no window,
+GPU, OpenGL, or multiprocessing dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import math
+import os
+from pathlib import Path
+import time
+from typing import Iterable, Sequence
+
+# Keep vendor BLAS implementations from turning small camera transforms into a
+# multi-core workload. Callers can explicitly override these before startup.
+for _thread_variable in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+):
+    os.environ.setdefault(_thread_variable, "1")
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+import trimesh
+
+
+HARD_MAX_RESOLUTION = 2048
+HARD_MAX_TRIANGLES = 2_000_000
+DEFAULT_OUTPUT_SIZE = 640
+DEFAULT_MAX_RESOLUTION = 1280
+DEFAULT_MAX_TRIANGLES = 500_000
+MAX_SUPERSAMPLE = 2
+CONTACT_VIEWS = ("isometric", "front", "side", "top")
+SUPPORTED_VIEWS = (*CONTACT_VIEWS, "bottom")
+BACKGROUND = (255, 255, 255)
+DEFAULT_MATERIAL = (122, 163, 199)
+LIGHT = np.array((0.35, -0.55, 0.76), dtype=np.float64)
+LIGHT /= np.linalg.norm(LIGHT)
+
+
+def _camera_direction(elevation: float, azimuth: float) -> tuple[float, float, float]:
+    elevation_radians = math.radians(elevation)
+    azimuth_radians = math.radians(azimuth)
+    return (
+        math.cos(elevation_radians) * math.cos(azimuth_radians),
+        math.cos(elevation_radians) * math.sin(azimuth_radians),
+        math.sin(elevation_radians),
+    )
+
+
+CAMERA_DIRECTIONS = {
+    "isometric": _camera_direction(28.0, 42.0),
+    "front": _camera_direction(0.0, -90.0),
+    "side": _camera_direction(0.0, 0.0),
+    "top": (0.0, 0.0, 1.0),
+    "bottom": (0.0, 0.0, -1.0),
+}
+
+
+@dataclass(frozen=True)
+class RenderLimits:
+    """Per-invocation safety limits; hard caps cannot be raised from the CLI."""
+
+    max_resolution: int = DEFAULT_MAX_RESOLUTION
+    max_triangles: int = DEFAULT_MAX_TRIANGLES
+    max_supersample: int = MAX_SUPERSAMPLE
+
+    def __post_init__(self) -> None:
+        if not 320 <= self.max_resolution <= HARD_MAX_RESOLUTION:
+            raise ValueError(
+                f"max resolution must be between 320 and {HARD_MAX_RESOLUTION}"
+            )
+        if not 1 <= self.max_triangles <= HARD_MAX_TRIANGLES:
+            raise ValueError(
+                f"max triangles must be between 1 and {HARD_MAX_TRIANGLES}"
+            )
+        if not 1 <= self.max_supersample <= MAX_SUPERSAMPLE:
+            raise ValueError(f"max supersample must be between 1 and {MAX_SUPERSAMPLE}")
+
+
+@dataclass(frozen=True)
+class MeshInput:
+    name: str
+    mesh: trimesh.Trimesh
+    color: tuple[int, int, int] = DEFAULT_MATERIAL
+    path: Path | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.mesh, trimesh.Trimesh) or self.mesh.is_empty:
+            raise ValueError(f"no renderable mesh in {self.name}")
+        if not np.isfinite(self.mesh.vertices).all():
+            raise ValueError(f"non-finite mesh vertices in {self.name}")
+        if len(self.color) != 3 or any(value < 0 or value > 255 for value in self.color):
+            raise ValueError(f"invalid RGB color for {self.name}: {self.color!r}")
+
+
+@dataclass
+class RenderStats:
+    view: str
+    elapsed_seconds: float
+    triangles_input: int
+    backface_culled: int
+    frustum_culled: int
+    frustum_clipped: int
+    screen_culled: int
+    degenerate_culled: int
+    triangles_rasterized: int
+    covered_pixels: int
+    buffer_bytes: int
+
+    def to_dict(self) -> dict[str, int | float | str]:
+        result = asdict(self)
+        result["elapsed_seconds"] = round(self.elapsed_seconds, 6)
+        return result
+
+
+@dataclass
+class ViewRender:
+    image: Image.Image
+    stats: RenderStats
+
+
+@dataclass
+class ContactRender:
+    image: Image.Image
+    stats: list[RenderStats]
+    elapsed_seconds: float
+    peak_buffer_bytes: int
+
+
+class BufferPool:
+    """One depth/color allocation reused by sequential view renders."""
+
+    def __init__(self) -> None:
+        self.depth: np.ndarray | None = None
+        self.color: np.ndarray | None = None
+        self.max_bytes = 0
+
+    def prepare(
+        self,
+        width: int,
+        height: int,
+        background: tuple[int, int, int] = BACKGROUND,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        shape = (height, width)
+        if self.depth is None or self.depth.shape != shape:
+            self.depth = np.empty(shape, dtype=np.float32)
+            self.color = np.empty((*shape, 3), dtype=np.uint8)
+        assert self.color is not None
+        self.depth.fill(-np.inf)
+        self.color[:, :] = background
+        self.max_bytes = max(self.max_bytes, self.depth.nbytes + self.color.nbytes)
+        return self.depth, self.color
+
+
+def load_mesh(path: Path | str, *, process: bool = True) -> trimesh.Trimesh:
+    source = Path(path).resolve()
+    mesh = trimesh.load(source, force="mesh", process=process)
+    if not isinstance(mesh, trimesh.Trimesh) or mesh.is_empty:
+        raise ValueError(f"no renderable mesh in {source}")
+    if not np.isfinite(mesh.vertices).all():
+        raise ValueError(f"non-finite mesh vertices in {source}")
+    return mesh
+
+
+def triangle_count(meshes: Sequence[MeshInput]) -> int:
+    return sum(len(item.mesh.faces) for item in meshes)
+
+
+def mesh_bounds(meshes: Sequence[MeshInput]) -> tuple[np.ndarray, np.ndarray]:
+    _validate_meshes(meshes)
+    bounds = np.array([item.mesh.bounds for item in meshes], dtype=np.float64)
+    return bounds[:, 0].min(axis=0), bounds[:, 1].max(axis=0)
+
+
+def _validate_meshes(meshes: Sequence[MeshInput]) -> None:
+    if not meshes:
+        raise ValueError("at least one mesh is required")
+
+
+def _validate_request(
+    meshes: Sequence[MeshInput],
+    width: int,
+    height: int,
+    supersample: int,
+    limits: RenderLimits,
+) -> None:
+    _validate_meshes(meshes)
+    if width < 1 or height < 1:
+        raise ValueError("render width and height must be positive")
+    if supersample < 1 or supersample > limits.max_supersample:
+        raise ValueError(
+            f"supersample must be between 1 and {limits.max_supersample}"
+        )
+    if max(width, height) * supersample > limits.max_resolution:
+        raise ValueError(
+            "internal render resolution exceeds the configured maximum "
+            f"of {limits.max_resolution} pixels"
+        )
+    count = triangle_count(meshes)
+    if count > limits.max_triangles:
+        raise ValueError(
+            f"mesh has {count} triangles; configured maximum is {limits.max_triangles}"
+        )
+
+
+def _camera_basis(view: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    if view not in CAMERA_DIRECTIONS:
+        raise ValueError(f"unsupported view {view!r}; choose from {SUPPORTED_VIEWS}")
+    eye = np.asarray(CAMERA_DIRECTIONS[view], dtype=np.float64)
+    eye /= np.linalg.norm(eye)
+    up_hint = (
+        np.array((0.0, 1.0, 0.0), dtype=np.float64)
+        if abs(float(eye[2])) > 0.95
+        else np.array((0.0, 0.0, 1.0), dtype=np.float64)
+    )
+    right = np.cross(up_hint, eye)
+    right /= np.linalg.norm(right)
+    up = np.cross(eye, right)
+    up /= np.linalg.norm(up)
+    return right, up, eye
+
+
+def _face_colors(mesh: trimesh.Trimesh, base_color: tuple[int, int, int]) -> np.ndarray:
+    normals = np.asarray(mesh.face_normals, dtype=np.float64)
+    facing_light = np.einsum("ij,j->i", normals, LIGHT)
+    intensity = 0.42 + 0.58 * np.clip(facing_light, 0.0, 1.0)
+    base = np.asarray(base_color, dtype=np.float64)
+    return np.clip(np.rint(intensity[:, None] * base[None, :]), 0, 255).astype(
+        np.uint8
+    )
+
+
+def _edge(
+    ax: float,
+    ay: float,
+    bx: float,
+    by: float,
+    x: np.ndarray,
+    y: np.ndarray,
+) -> np.ndarray:
+    return (bx - ax) * (y - ay) - (by - ay) * (x - ax)
+
+
+def _clip_polygon_axis(
+    polygon: np.ndarray,
+    axis: int,
+    boundary: float,
+    keep_greater: bool,
+) -> np.ndarray:
+    if len(polygon) == 0:
+        return polygon
+
+    def inside(point: np.ndarray) -> bool:
+        return bool(
+            point[axis] >= boundary if keep_greater else point[axis] <= boundary
+        )
+
+    output: list[np.ndarray] = []
+    previous = polygon[-1]
+    previous_inside = inside(previous)
+    for current in polygon:
+        current_inside = inside(current)
+        if current_inside != previous_inside:
+            denominator = current[axis] - previous[axis]
+            amount = 0.0 if abs(float(denominator)) < 1e-15 else (
+                boundary - previous[axis]
+            ) / denominator
+            output.append(previous + amount * (current - previous))
+        if current_inside:
+            output.append(current)
+        previous = current
+        previous_inside = current_inside
+    return np.asarray(output, dtype=np.float64).reshape((-1, 3))
+
+
+def _clip_to_viewport(
+    triangle: np.ndarray,
+    width: int,
+    height: int,
+    near_depth: float,
+    far_depth: float,
+) -> np.ndarray:
+    polygon = triangle
+    for axis, boundary, keep_greater in (
+        (0, 0.0, True),
+        (0, float(width), False),
+        (1, 0.0, True),
+        (1, float(height), False),
+        (2, near_depth, True),
+        (2, far_depth, False),
+    ):
+        polygon = _clip_polygon_axis(polygon, axis, boundary, keep_greater)
+        if len(polygon) < 3:
+            break
+    return polygon
+
+
+def _rasterize_triangle(
+    triangle: np.ndarray,
+    face_color: np.ndarray,
+    depth_buffer: np.ndarray,
+    color_buffer: np.ndarray,
+    depth_epsilon: float,
+) -> bool:
+    height, width = depth_buffer.shape
+    points = triangle.copy()
+    area = float(
+        _edge(
+            points[0, 0],
+            points[0, 1],
+            points[1, 0],
+            points[1, 1],
+            np.asarray(points[2, 0]),
+            np.asarray(points[2, 1]),
+        )
+    )
+    if abs(area) <= 1e-10:
+        return False
+    if area < 0.0:
+        points[[1, 2]] = points[[2, 1]]
+        area = -area
+
+    min_x = max(0, int(math.ceil(float(points[:, 0].min()) - 0.5)))
+    max_x = min(width - 1, int(math.floor(float(points[:, 0].max()) - 0.5)))
+    min_y = max(0, int(math.ceil(float(points[:, 1].min()) - 0.5)))
+    max_y = min(height - 1, int(math.floor(float(points[:, 1].max()) - 0.5)))
+    if min_x > max_x or min_y > max_y:
+        return False
+
+    xs = np.arange(min_x, max_x + 1, dtype=np.float64)[None, :] + 0.5
+    edge_tolerance = max(area * 1e-12, 1e-9)
+    wrote_pixel = False
+    for row_start in range(min_y, max_y + 1, 32):
+        row_stop = min(row_start + 32, max_y + 1)
+        ys = np.arange(row_start, row_stop, dtype=np.float64)[:, None] + 0.5
+        weight0 = _edge(
+            points[1, 0], points[1, 1], points[2, 0], points[2, 1], xs, ys
+        )
+        weight1 = _edge(
+            points[2, 0], points[2, 1], points[0, 0], points[0, 1], xs, ys
+        )
+        weight2 = _edge(
+            points[0, 0], points[0, 1], points[1, 0], points[1, 1], xs, ys
+        )
+        covered = (
+            (weight0 >= -edge_tolerance)
+            & (weight1 >= -edge_tolerance)
+            & (weight2 >= -edge_tolerance)
+        )
+        if not covered.any():
+            continue
+        candidate_depth = (
+            weight0 * points[0, 2]
+            + weight1 * points[1, 2]
+            + weight2 * points[2, 2]
+        ) / area
+        current_depth = depth_buffer[row_start:row_stop, min_x : max_x + 1]
+        nearer = covered & (candidate_depth > current_depth + depth_epsilon)
+        if not nearer.any():
+            continue
+        current_depth[nearer] = candidate_depth[nearer]
+        color_slice = color_buffer[row_start:row_stop, min_x : max_x + 1]
+        color_slice[nearer] = face_color
+        wrote_pixel = True
+    return wrote_pixel
+
+
+def _render_internal(
+    meshes: Sequence[MeshInput],
+    view: str,
+    width: int,
+    height: int,
+    pool: BufferPool,
+    background: tuple[int, int, int],
+) -> ViewRender:
+    started = time.perf_counter()
+    right, up, eye = _camera_basis(view)
+    basis = np.column_stack((right, up, eye))
+    bounds = np.asarray([item.mesh.bounds for item in meshes], dtype=np.float64)
+    world_center = (bounds[:, 0].min(axis=0) + bounds[:, 1].max(axis=0)) / 2.0
+    camera_vertices = [
+        np.einsum(
+            "ij,jk->ik",
+            np.asarray(item.mesh.vertices, dtype=np.float64) - world_center,
+            basis,
+        )
+        for item in meshes
+    ]
+    camera_low = np.min(
+        np.asarray([vertices.min(axis=0) for vertices in camera_vertices]), axis=0
+    )
+    camera_high = np.max(
+        np.asarray([vertices.max(axis=0) for vertices in camera_vertices]), axis=0
+    )
+    screen_low = camera_low[:2]
+    screen_high = camera_high[:2]
+    screen_center = (screen_low + screen_high) / 2.0
+    raw_span = screen_high - screen_low
+    world_span = max(float((camera_high - camera_low).max()), 1e-9)
+    span = np.maximum(raw_span, world_span * 1e-6)
+    margin = 0.08
+    scale = min(
+        width / (float(span[0]) * (1.0 + margin * 2.0)),
+        height / (float(span[1]) * (1.0 + margin * 2.0)),
+    )
+    half_x = width / (2.0 * scale)
+    half_y = height / (2.0 * scale)
+    near_depth = float(camera_low[2]) - world_span * 1e-6
+    far_depth = float(camera_high[2]) + world_span * 1e-6
+    depth_epsilon = max((far_depth - near_depth) * 1e-7, 1e-10)
+    depth_buffer, color_buffer = pool.prepare(width, height, background)
+
+    triangles_input = triangle_count(meshes)
+    backface_culled = 0
+    frustum_culled = 0
+    frustum_clipped = 0
+    screen_culled = 0
+    degenerate_culled = 0
+    triangles_rasterized = 0
+
+    for item, vertices in zip(meshes, camera_vertices):
+        faces = np.asarray(item.mesh.faces, dtype=np.int64)
+        normals = np.asarray(item.mesh.face_normals, dtype=np.float64)
+        facing = np.einsum("ij,j->i", normals, eye)
+        front_mask = facing > 1e-12
+        backface_culled += int((~front_mask).sum())
+        if not front_mask.any():
+            continue
+        faces = faces[front_mask]
+        colors = _face_colors(item.mesh, item.color)[front_mask]
+        camera_triangles = vertices[faces]
+
+        left = screen_center[0] - half_x
+        right_plane = screen_center[0] + half_x
+        bottom = screen_center[1] - half_y
+        top = screen_center[1] + half_y
+        outside = (
+            np.all(camera_triangles[:, :, 0] < left, axis=1)
+            | np.all(camera_triangles[:, :, 0] > right_plane, axis=1)
+            | np.all(camera_triangles[:, :, 1] < bottom, axis=1)
+            | np.all(camera_triangles[:, :, 1] > top, axis=1)
+            | np.all(camera_triangles[:, :, 2] < near_depth, axis=1)
+            | np.all(camera_triangles[:, :, 2] > far_depth, axis=1)
+        )
+        frustum_culled += int(outside.sum())
+        if outside.all():
+            continue
+        camera_triangles = camera_triangles[~outside]
+        colors = colors[~outside]
+
+        screen_triangles = np.empty_like(camera_triangles)
+        screen_triangles[:, :, 0] = (
+            (camera_triangles[:, :, 0] - screen_center[0]) * scale + width / 2.0
+        )
+        screen_triangles[:, :, 1] = (
+            (screen_center[1] - camera_triangles[:, :, 1]) * scale + height / 2.0
+        )
+        screen_triangles[:, :, 2] = camera_triangles[:, :, 2]
+        offscreen = (
+            np.all(screen_triangles[:, :, 0] < 0.0, axis=1)
+            | np.all(screen_triangles[:, :, 0] > width, axis=1)
+            | np.all(screen_triangles[:, :, 1] < 0.0, axis=1)
+            | np.all(screen_triangles[:, :, 1] > height, axis=1)
+        )
+        screen_culled += int(offscreen.sum())
+        if offscreen.all():
+            continue
+        screen_triangles = screen_triangles[~offscreen]
+        colors = colors[~offscreen]
+
+        partially_clipped = (
+            np.any(screen_triangles[:, :, 0] < 0.0, axis=1)
+            | np.any(screen_triangles[:, :, 0] > width, axis=1)
+            | np.any(screen_triangles[:, :, 1] < 0.0, axis=1)
+            | np.any(screen_triangles[:, :, 1] > height, axis=1)
+            | np.any(screen_triangles[:, :, 2] < near_depth, axis=1)
+            | np.any(screen_triangles[:, :, 2] > far_depth, axis=1)
+        )
+        frustum_clipped += int(partially_clipped.sum())
+
+        for triangle, color, clipped in zip(
+            screen_triangles, colors, partially_clipped
+        ):
+            polygon = (
+                _clip_to_viewport(
+                    triangle, width, height, near_depth, far_depth
+                )
+                if clipped
+                else triangle
+            )
+            if len(polygon) < 3:
+                degenerate_culled += 1
+                continue
+            wrote_triangle = False
+            for index in range(1, len(polygon) - 1):
+                clipped_triangle = np.stack(
+                    (polygon[0], polygon[index], polygon[index + 1])
+                )
+                wrote_triangle |= _rasterize_triangle(
+                    clipped_triangle,
+                    color,
+                    depth_buffer,
+                    color_buffer,
+                    depth_epsilon,
+                )
+            if wrote_triangle:
+                triangles_rasterized += 1
+            else:
+                degenerate_culled += 1
+
+    image = Image.fromarray(color_buffer.copy(), mode="RGB")
+    elapsed = time.perf_counter() - started
+    return ViewRender(
+        image=image,
+        stats=RenderStats(
+            view=view,
+            elapsed_seconds=elapsed,
+            triangles_input=triangles_input,
+            backface_culled=backface_culled,
+            frustum_culled=frustum_culled,
+            frustum_clipped=frustum_clipped,
+            screen_culled=screen_culled,
+            degenerate_culled=degenerate_culled,
+            triangles_rasterized=triangles_rasterized,
+            covered_pixels=int(np.count_nonzero(np.isfinite(depth_buffer))),
+            buffer_bytes=depth_buffer.nbytes + color_buffer.nbytes,
+        ),
+    )
+
+
+def render_view(
+    meshes: Sequence[MeshInput],
+    view: str,
+    width: int,
+    height: int | None = None,
+    *,
+    supersample: int = 1,
+    limits: RenderLimits = RenderLimits(),
+    pool: BufferPool | None = None,
+    background: tuple[int, int, int] = BACKGROUND,
+) -> ViewRender:
+    output_height = height if height is not None else width
+    _validate_request(meshes, width, output_height, supersample, limits)
+    render_pool = pool if pool is not None else BufferPool()
+    result = _render_internal(
+        meshes,
+        view,
+        width * supersample,
+        output_height * supersample,
+        render_pool,
+        background,
+    )
+    if supersample == 1:
+        return result
+    result.image = result.image.resize(
+        (width, output_height), resample=Image.Resampling.LANCZOS
+    )
+    return result
+
+
+def _centered_text(
+    draw: ImageDraw.ImageDraw,
+    bounds: tuple[int, int, int, int],
+    text: str,
+    fill: tuple[int, int, int],
+    font: ImageFont.ImageFont,
+) -> None:
+    left, top, right, bottom = bounds
+    box = draw.textbbox((0, 0), text, font=font)
+    width = box[2] - box[0]
+    height = box[3] - box[1]
+    draw.text(
+        (left + (right - left - width) / 2, top + (bottom - top - height) / 2),
+        text,
+        fill=fill,
+        font=font,
+    )
+
+
+def render_contact_sheet(
+    meshes: Sequence[MeshInput],
+    pixels: int,
+    *,
+    title: str,
+    supersample: int = 1,
+    limits: RenderLimits = RenderLimits(),
+    views: Iterable[str] = CONTACT_VIEWS,
+) -> ContactRender:
+    requested_views = tuple(views)
+    if len(requested_views) != 4:
+        raise ValueError("the contact sheet requires exactly four views")
+    if pixels < 320:
+        raise ValueError("contact sheet size must be at least 320")
+    if pixels > limits.max_resolution:
+        raise ValueError(
+            f"contact sheet size exceeds the configured maximum of {limits.max_resolution}"
+        )
+
+    started = time.perf_counter()
+    sheet = Image.new("RGB", (pixels, pixels), BACKGROUND)
+    draw = ImageDraw.Draw(sheet)
+    font = ImageFont.load_default()
+    header_height = max(34, pixels // 20)
+    gutter = max(8, pixels // 75)
+    label_height = max(18, pixels // 40)
+    panel_width = (pixels - gutter * 3) // 2
+    panel_height = (pixels - header_height - gutter * 3 - label_height * 2) // 2
+    if panel_width < 1 or panel_height < 1:
+        raise ValueError("contact sheet size is too small for four views")
+    _validate_request(meshes, panel_width, panel_height, supersample, limits)
+
+    _centered_text(
+        draw,
+        (gutter, 0, pixels - gutter, header_height),
+        title,
+        (36, 49, 61),
+        font,
+    )
+    pool = BufferPool()
+    stats: list[RenderStats] = []
+    for index, view in enumerate(requested_views):
+        column = index % 2
+        row = index // 2
+        left = gutter + column * (panel_width + gutter)
+        top = header_height + gutter + row * (panel_height + label_height + gutter)
+        rendered = render_view(
+            meshes,
+            view,
+            panel_width,
+            panel_height,
+            supersample=supersample,
+            limits=limits,
+            pool=pool,
+        )
+        sheet.paste(rendered.image, (left, top))
+        _centered_text(
+            draw,
+            (left, top + panel_height, left + panel_width, top + panel_height + label_height),
+            view,
+            (36, 49, 61),
+            font,
+        )
+        stats.append(rendered.stats)
+    return ContactRender(
+        image=sheet,
+        stats=stats,
+        elapsed_seconds=time.perf_counter() - started,
+        peak_buffer_bytes=pool.max_bytes,
+    )

--- a/skills/text-a3d-color/SKILL.md
+++ b/skills/text-a3d-color/SKILL.md
@@ -37,9 +37,15 @@ session working directory.
 - Read `references/color-architecture.md` before choosing region interfaces
 - Read `references/bambu-printability.md` before every printable color task
 
-Requires build123d, lib3mf, trimesh, Rtree, matplotlib, Pillow, and NumPy. When
-running outside Amagine3D's managed session, initialize the repository runtime
-and use its Python executable instead of an unrelated system Python.
+Requires build123d, lib3mf, trimesh, Rtree, Pillow, and NumPy. Preview rendering uses
+the headless, single-process CPU Z-buffer in `../cpu_z_buffer.py`; it does not
+need a GPU, display server, OpenGL, or Matplotlib.
+The renderer defaults to a 640-pixel output, 1x supersampling, a 1280-pixel
+internal view limit, and 500,000 input triangles. `--supersample 2`,
+`--max-resolution`, and
+`--max-triangles` may adjust those values within the built-in hard caps.
+When running outside Amagine3D's managed session, initialize the repository
+runtime and use its Python executable instead of an unrelated system Python.
 
 ## 0. Route and interpret color
 

--- a/skills/text-a3d-color/render_preview.py
+++ b/skills/text-a3d-color/render_preview.py
@@ -9,49 +9,51 @@ import json
 from pathlib import Path
 import re
 import sys
+import tracemalloc
 
-import matplotlib
 
-matplotlib.use("Agg")
+SKILLS_ROOT = Path(__file__).resolve().parents[1]
+if str(SKILLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SKILLS_ROOT))
 
-import matplotlib.pyplot as plt
-import numpy as np
-import trimesh
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+from cpu_z_buffer import (  # noqa: E402
+    CONTACT_VIEWS,
+    DEFAULT_MAX_RESOLUTION,
+    DEFAULT_OUTPUT_SIZE,
+    DEFAULT_MAX_TRIANGLES,
+    HARD_MAX_RESOLUTION,
+    HARD_MAX_TRIANGLES,
+    MAX_SUPERSAMPLE,
+    SUPPORTED_VIEWS,
+    MeshInput,
+    RenderLimits,
+    load_mesh,
+    mesh_bounds,
+    render_contact_sheet,
+    render_view,
+    triangle_count,
+)
 
 
 HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
-CAMERAS = {
-    "isometric": (28, 42),
-    "front": (0, -90),
-    "side": (0, 0),
-    "top": (89.9, -90),
-}
-REFERENCE_CAMERAS = {**CAMERAS, "bottom": (-89.9, -90)}
-LIGHT = np.array([0.35, -0.55, 0.76], dtype=float)
-LIGHT /= np.linalg.norm(LIGHT)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Region:
     name: str
     path: Path
     color: str
-    mesh: trimesh.Trimesh
-    facecolors: np.ndarray
+    render_input: MeshInput
 
 
 def _digest(path: Path) -> str:
     return sha256(path.read_bytes()).hexdigest()
 
 
-def _rgb(value: str) -> np.ndarray:
+def _rgb(value: str) -> tuple[int, int, int]:
     if not HEX.fullmatch(value):
         raise ValueError(f"invalid region color {value!r}; expected #RRGGBB")
-    return np.array(
-        [int(value[index:index + 2], 16) / 255 for index in (1, 3, 5)],
-        dtype=float,
-    )
+    return tuple(int(value[index : index + 2], 16) for index in (1, 3, 5))
 
 
 def _region(specification: str) -> Region:
@@ -59,85 +61,42 @@ def _region(specification: str) -> Region:
     if not separator or not filename:
         raise ValueError(f"bad --part value {specification!r}; expected path.stl=#RRGGBB")
     path = Path(filename).resolve()
-    mesh = trimesh.load(path, force="mesh", process=True)
-    if not isinstance(mesh, trimesh.Trimesh) or mesh.is_empty:
-        raise ValueError(f"no renderable mesh in {path}")
-    if not np.isfinite(mesh.vertices).all():
-        raise ValueError(f"non-finite vertices in {path}")
-    color = color.upper()
-    base = _rgb(color)
-    facing = np.einsum("ij,j->i", mesh.face_normals, LIGHT)
-    intensity = 0.42 + 0.58 * np.clip(facing, 0.0, 1.0)
-    facecolors = np.column_stack((np.outer(intensity, base), np.ones(len(intensity))))
-    return Region(path.stem, path, color, mesh, facecolors)
+    mesh = load_mesh(path)
+    normalized_color = color.upper()
+    render_input = MeshInput(path.stem, mesh, _rgb(normalized_color), path)
+    return Region(path.stem, path, normalized_color, render_input)
 
 
-def _bounds(regions: list[Region]) -> tuple[np.ndarray, np.ndarray]:
-    stack = np.array([region.mesh.bounds for region in regions])
-    return stack[:, 0].min(axis=0), stack[:, 1].max(axis=0)
-
-
-def _frame(axis, regions: list[Region], camera: tuple[float, float]) -> None:
-    low, high = _bounds(regions)
-    spans = high - low
-    center = (low + high) / 2
-    margin = max(float(spans.max()) * 0.06, 0.05)
-    half = np.maximum(spans / 2 + margin, 0.05)
-    triangles = np.concatenate([region.mesh.triangles for region in regions])
-    colors = np.concatenate([region.facecolors for region in regions])
-    axis.add_collection3d(Poly3DCollection(
-        triangles,
-        facecolors=colors,
-        edgecolors=(0.08, 0.09, 0.10, 0.12),
-        linewidths=0.10,
-        antialiased=True,
-    ))
-    axis.set_xlim(center[0] - half[0], center[0] + half[0])
-    axis.set_ylim(center[1] - half[1], center[1] + half[1])
-    axis.set_zlim(center[2] - half[2], center[2] + half[2])
-    axis.set_box_aspect(np.maximum(spans, 1e-6))
-    axis.set_proj_type("ortho")
-    axis.view_init(elev=camera[0], azim=camera[1])
-    axis.set_axis_off()
-
-
-def _contact(regions: list[Region], destination: Path, pixels: int) -> None:
+def _save_png(image, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    figure = plt.figure(figsize=(pixels / 100, pixels / 100), dpi=100)
-    for index, (name, camera) in enumerate(CAMERAS.items(), start=1):
-        axis = figure.add_subplot(2, 2, index, projection="3d")
-        _frame(axis, regions, camera)
-        axis.set_title(name, fontsize=9, color="#24313d")
-    low, high = _bounds(regions)
-    dimensions = high - low
-    palette = "  ".join(region.color for region in regions)
-    figure.suptitle(
-        f"{len(regions)} regions  ·  {dimensions[0]:.2f} × "
-        f"{dimensions[1]:.2f} × {dimensions[2]:.2f} mm  ·  {palette}",
-        fontsize=9,
-        color="#24313d",
-    )
-    figure.tight_layout()
-    figure.savefig(destination, bbox_inches="tight", facecolor="white")
-    plt.close(figure)
-
-
-def _matched(regions, camera, destination: Path, pixels: int) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    figure = plt.figure(figsize=(pixels / 100, pixels / 100), dpi=100)
-    axis = figure.add_subplot(1, 1, 1, projection="3d")
-    _frame(axis, regions, camera)
-    figure.subplots_adjust(left=0, right=1, bottom=0, top=1)
-    figure.savefig(destination, bbox_inches="tight", pad_inches=0, facecolor="white")
-    plt.close(figure)
+    image.save(destination, format="PNG")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--part", action="append", required=True)
     parser.add_argument("--out", required=True)
-    parser.add_argument("--size", type=int, default=900)
-    parser.add_argument("--reference-view", choices=REFERENCE_CAMERAS)
+    parser.add_argument("--size", type=int, default=DEFAULT_OUTPUT_SIZE)
+    parser.add_argument(
+        "--supersample",
+        type=int,
+        choices=range(1, MAX_SUPERSAMPLE + 1),
+        default=1,
+        help="Render at 1x (default) or 2x, then downsample with Pillow",
+    )
+    parser.add_argument(
+        "--max-resolution",
+        type=int,
+        default=DEFAULT_MAX_RESOLUTION,
+        help=f"Internal per-view pixel limit (hard maximum {HARD_MAX_RESOLUTION})",
+    )
+    parser.add_argument(
+        "--max-triangles",
+        type=int,
+        default=DEFAULT_MAX_TRIANGLES,
+        help=f"Input triangle limit (hard maximum {HARD_MAX_TRIANGLES})",
+    )
+    parser.add_argument("--reference-view", choices=SUPPORTED_VIEWS)
     parser.add_argument("--reference-out")
     parser.add_argument("--report", help="Optional JSON evidence report")
     args = parser.parse_args()
@@ -146,46 +105,119 @@ def main() -> int:
     if args.size < 320:
         parser.error("--size must be at least 320")
 
+    tracing_was_active = tracemalloc.is_tracing()
+    if not tracing_was_active:
+        tracemalloc.start()
+    tracemalloc.reset_peak()
     try:
+        limits = RenderLimits(
+            max_resolution=args.max_resolution,
+            max_triangles=args.max_triangles,
+        )
+        if args.reference_view and args.size * args.supersample > limits.max_resolution:
+            raise ValueError(
+                "matched-view internal resolution exceeds the configured maximum "
+                f"of {limits.max_resolution} pixels"
+            )
         regions = [_region(item) for item in args.part]
+        inputs = [region.render_input for region in regions]
+        count = triangle_count(inputs)
+        if count > limits.max_triangles:
+            raise ValueError(
+                f"meshes have {count} triangles; configured maximum is "
+                f"{limits.max_triangles}"
+            )
+        destination = Path(args.out).resolve()
+        low, high = mesh_bounds(inputs)
+        dimensions = high - low
+        palette = "  ".join(region.color for region in regions)
+        contact = render_contact_sheet(
+            inputs,
+            args.size,
+            title=(
+                f"{len(regions)} regions  |  {dimensions[0]:.2f} x "
+                f"{dimensions[1]:.2f} x {dimensions[2]:.2f} mm  |  {palette}"
+            ),
+            supersample=args.supersample,
+            limits=limits,
+        )
+        _save_png(contact.image, destination)
+
+        matched_stats = None
+        matched_path = None
+        if args.reference_view:
+            matched_path = Path(args.reference_out).resolve()
+            matched = render_view(
+                inputs,
+                args.reference_view,
+                args.size,
+                supersample=args.supersample,
+                limits=limits,
+            )
+            _save_png(matched.image, matched_path)
+            matched_stats = matched.stats
+
+        _, traced_peak = tracemalloc.get_traced_memory()
+        peak_buffer_bytes = max(
+            contact.peak_buffer_bytes,
+            matched_stats.buffer_bytes if matched_stats is not None else 0,
+        )
+        result = {
+            "dimensions_mm": [round(float(value), 4) for value in dimensions],
+            "performance": {
+                "four_view_seconds": round(contact.elapsed_seconds, 6),
+                "parallel_views": False,
+                "peak_memory_bytes": max(int(traced_peak), peak_buffer_bytes),
+                "processes": 1,
+                "supersample": args.supersample,
+                "triangle_count": count,
+                "views": {stat.view: stat.to_dict() for stat in contact.stats},
+            },
+            "preview": {
+                "path": str(destination),
+                "sha256": _digest(destination),
+            },
+            "projection": "orthographic",
+            "regions": [
+                {
+                    "color": region.color,
+                    "dimensions_mm": [
+                        round(float(value), 4)
+                        for value in region.render_input.mesh.extents
+                    ],
+                    "name": region.name,
+                    "path": str(region.path),
+                    "sha256": _digest(region.path),
+                    "watertight": bool(region.render_input.mesh.is_watertight),
+                }
+                for region in regions
+            ],
+            "renderer": "cpu-z-buffer/v1",
+            "schema": "evidence-color-render/v2",
+            "supported_views": list(SUPPORTED_VIEWS),
+            "views": list(CONTACT_VIEWS),
+        }
+        if matched_path is not None and matched_stats is not None:
+            result["matched_view"] = {
+                "name": args.reference_view,
+                "path": str(matched_path),
+                "sha256": _digest(matched_path),
+            }
+            result["performance"]["single_view_seconds"] = round(
+                matched_stats.elapsed_seconds, 6
+            )
+        payload = json.dumps(result, indent=2)
+        if args.report:
+            report = Path(args.report).resolve()
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(payload + "\n", encoding="utf-8")
+        print(payload)
+        return 0
     except (OSError, ValueError) as error:
         parser.error(str(error))
-    destination = Path(args.out)
-    _contact(regions, destination, args.size)
-    low, high = _bounds(regions)
-    result = {
-        "dimensions_mm": [round(float(value), 4) for value in high - low],
-        "preview": {"path": str(destination.resolve()), "sha256": _digest(destination)},
-        "projection": "orthographic",
-        "regions": [
-            {
-                "color": region.color,
-                "dimensions_mm": [round(float(value), 4) for value in region.mesh.extents],
-                "name": region.name,
-                "path": str(region.path),
-                "sha256": _digest(region.path),
-                "watertight": bool(region.mesh.is_watertight),
-            }
-            for region in regions
-        ],
-        "schema": "evidence-color-render/v2",
-        "views": list(CAMERAS),
-    }
-    if args.reference_view:
-        matched = Path(args.reference_out)
-        _matched(regions, REFERENCE_CAMERAS[args.reference_view], matched, args.size)
-        result["matched_view"] = {
-            "name": args.reference_view,
-            "path": str(matched.resolve()),
-            "sha256": _digest(matched),
-        }
-    payload = json.dumps(result, indent=2)
-    if args.report:
-        report = Path(args.report)
-        report.parent.mkdir(parents=True, exist_ok=True)
-        report.write_text(payload + "\n", encoding="utf-8")
-    print(payload)
-    return 0
+    finally:
+        if not tracing_was_active:
+            tracemalloc.stop()
 
 
 if __name__ == "__main__":

--- a/skills/text-a3d/SKILL.md
+++ b/skills/text-a3d/SKILL.md
@@ -35,7 +35,13 @@ session working directory.
 - Read `references/construction-strategies.md` before writing geometry
 - Read `references/bambu-printability.md` before every generated printable part
 
-Requires build123d, trimesh, Rtree, matplotlib, Pillow, and NumPy.
+Requires build123d, trimesh, Rtree, Pillow, and NumPy. Preview rendering uses the
+headless, single-process CPU Z-buffer in `../cpu_z_buffer.py`; it does not need
+a GPU, display server, OpenGL, or Matplotlib.
+The renderer defaults to a 640-pixel output, 1x supersampling, a 1280-pixel
+internal view limit, and 500,000 input triangles. `--supersample 2`,
+`--max-resolution`, and
+`--max-triangles` may adjust those values within the built-in hard caps.
 
 ## 0. Route before modeling
 

--- a/skills/text-a3d/render_preview.py
+++ b/skills/text-a3d/render_preview.py
@@ -3,118 +3,70 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 from hashlib import sha256
 import json
 from pathlib import Path
 import sys
-
-import matplotlib
-
-matplotlib.use("Agg")
-
-import matplotlib.pyplot as plt
-import numpy as np
-import trimesh
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+import tracemalloc
 
 
-@dataclass(frozen=True)
-class View:
-    label: str
-    elevation: float
-    azimuth: float
+SKILLS_ROOT = Path(__file__).resolve().parents[1]
+if str(SKILLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SKILLS_ROOT))
 
-
-VIEWS = {
-    "isometric": View("isometric", 28, 42),
-    "front": View("front", 0, -90),
-    "side": View("side", 0, 0),
-    "top": View("top", 89.9, -90),
-}
-REFERENCE_VIEWS = {**VIEWS, "bottom": View("bottom", -89.9, -90)}
-LIGHT = np.array([0.35, -0.55, 0.76], dtype=float)
-LIGHT /= np.linalg.norm(LIGHT)
+from cpu_z_buffer import (  # noqa: E402
+    CONTACT_VIEWS,
+    DEFAULT_MATERIAL,
+    DEFAULT_MAX_RESOLUTION,
+    DEFAULT_OUTPUT_SIZE,
+    DEFAULT_MAX_TRIANGLES,
+    HARD_MAX_RESOLUTION,
+    HARD_MAX_TRIANGLES,
+    MAX_SUPERSAMPLE,
+    SUPPORTED_VIEWS,
+    MeshInput,
+    RenderLimits,
+    load_mesh,
+    render_contact_sheet,
+    render_view,
+    triangle_count,
+)
 
 
 def _digest(path: Path) -> str:
     return sha256(path.read_bytes()).hexdigest()
 
 
-def _load(path: Path) -> trimesh.Trimesh:
-    mesh = trimesh.load(path, force="mesh", process=True)
-    if not isinstance(mesh, trimesh.Trimesh) or mesh.is_empty:
-        raise ValueError(f"no renderable mesh in {path}")
-    if not np.isfinite(mesh.vertices).all():
-        raise ValueError(f"non-finite mesh vertices in {path}")
-    return mesh
-
-
-def _shading(mesh: trimesh.Trimesh) -> np.ndarray:
-    facing = np.einsum("ij,j->i", mesh.face_normals, LIGHT)
-    intensity = 0.38 + 0.62 * np.clip(facing, 0.0, 1.0)
-    material = np.array([0.48, 0.64, 0.78])
-    return np.column_stack((np.outer(intensity, material), np.ones(len(intensity))))
-
-
-def _frame(ax, mesh: trimesh.Trimesh, colors: np.ndarray, view: View) -> None:
-    bounds = mesh.bounds
-    center = bounds.mean(axis=0)
-    spans = bounds[1] - bounds[0]
-    margin = max(float(spans.max()) * 0.06, 0.05)
-    half = np.maximum(spans / 2 + margin, 0.05)
-    collection = Poly3DCollection(
-        mesh.triangles,
-        facecolors=colors,
-        edgecolors=(0.10, 0.14, 0.18, 0.16),
-        linewidths=0.12,
-        antialiased=True,
-    )
-    ax.add_collection3d(collection)
-    ax.set_xlim(center[0] - half[0], center[0] + half[0])
-    ax.set_ylim(center[1] - half[1], center[1] + half[1])
-    ax.set_zlim(center[2] - half[2], center[2] + half[2])
-    ax.set_box_aspect(np.maximum(spans, 1e-6))
-    ax.set_proj_type("ortho")
-    ax.view_init(elev=view.elevation, azim=view.azimuth)
-    ax.set_axis_off()
-
-
-def _save_contact(mesh, colors, destination: Path, pixels: int) -> None:
+def _save_png(image, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    figure = plt.figure(figsize=(pixels / 100, pixels / 100), dpi=100)
-    for index, view in enumerate(VIEWS.values(), start=1):
-        axis = figure.add_subplot(2, 2, index, projection="3d")
-        _frame(axis, mesh, colors, view)
-        axis.set_title(view.label, fontsize=9, color="#24313d")
-    dimensions = mesh.extents
-    figure.suptitle(
-        "visual evidence  ·  "
-        f"{dimensions[0]:.2f} × {dimensions[1]:.2f} × {dimensions[2]:.2f} mm",
-        fontsize=10,
-        color="#24313d",
-    )
-    figure.tight_layout()
-    figure.savefig(destination, bbox_inches="tight", facecolor="white")
-    plt.close(figure)
-
-
-def _save_matched(mesh, colors, view: View, destination: Path, pixels: int) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    figure = plt.figure(figsize=(pixels / 100, pixels / 100), dpi=100)
-    axis = figure.add_subplot(1, 1, 1, projection="3d")
-    _frame(axis, mesh, colors, view)
-    figure.subplots_adjust(left=0, right=1, bottom=0, top=1)
-    figure.savefig(destination, bbox_inches="tight", pad_inches=0, facecolor="white")
-    plt.close(figure)
+    image.save(destination, format="PNG")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("stl")
     parser.add_argument("--out")
-    parser.add_argument("--size", type=int, default=900)
-    parser.add_argument("--reference-view", choices=REFERENCE_VIEWS)
+    parser.add_argument("--size", type=int, default=DEFAULT_OUTPUT_SIZE)
+    parser.add_argument(
+        "--supersample",
+        type=int,
+        choices=range(1, MAX_SUPERSAMPLE + 1),
+        default=1,
+        help="Render at 1x (default) or 2x, then downsample with Pillow",
+    )
+    parser.add_argument(
+        "--max-resolution",
+        type=int,
+        default=DEFAULT_MAX_RESOLUTION,
+        help=f"Internal per-view pixel limit (hard maximum {HARD_MAX_RESOLUTION})",
+    )
+    parser.add_argument(
+        "--max-triangles",
+        type=int,
+        default=DEFAULT_MAX_TRIANGLES,
+        help=f"Input triangle limit (hard maximum {HARD_MAX_TRIANGLES})",
+    )
+    parser.add_argument("--reference-view", choices=SUPPORTED_VIEWS)
     parser.add_argument("--reference-out")
     parser.add_argument("--report", help="Optional JSON evidence report")
     args = parser.parse_args()
@@ -123,40 +75,113 @@ def main() -> int:
     if args.size < 320:
         parser.error("--size must be at least 320")
 
-    source = Path(args.stl).resolve()
-    destination = Path(args.out or source.with_name(f"{source.stem}_views.png"))
-    mesh = _load(source)
-    colors = _shading(mesh)
-    _save_contact(mesh, colors, destination, args.size)
+    tracing_was_active = tracemalloc.is_tracing()
+    if not tracing_was_active:
+        tracemalloc.start()
+    tracemalloc.reset_peak()
+    try:
+        limits = RenderLimits(
+            max_resolution=args.max_resolution,
+            max_triangles=args.max_triangles,
+        )
+        if args.reference_view and args.size * args.supersample > limits.max_resolution:
+            raise ValueError(
+                "matched-view internal resolution exceeds the configured maximum "
+                f"of {limits.max_resolution} pixels"
+            )
+        source = Path(args.stl).resolve()
+        destination = Path(
+            args.out or source.with_name(f"{source.stem}_views.png")
+        ).resolve()
+        mesh = load_mesh(source)
+        inputs = [MeshInput(source.stem, mesh, DEFAULT_MATERIAL, source)]
+        count = triangle_count(inputs)
+        if count > limits.max_triangles:
+            raise ValueError(
+                f"mesh has {count} triangles; configured maximum is "
+                f"{limits.max_triangles}"
+            )
+        dimensions = mesh.extents
+        contact = render_contact_sheet(
+            inputs,
+            args.size,
+            title=(
+                "visual evidence  |  "
+                f"{dimensions[0]:.2f} x {dimensions[1]:.2f} x "
+                f"{dimensions[2]:.2f} mm"
+            ),
+            supersample=args.supersample,
+            limits=limits,
+        )
+        _save_png(contact.image, destination)
 
-    result = {
-        "checks": {
-            "finite_vertices": True,
-            "watertight": bool(mesh.is_watertight),
-            "winding_consistent": bool(mesh.is_winding_consistent),
-        },
-        "dimensions_mm": [round(float(value), 4) for value in mesh.extents],
-        "mesh": {"path": str(source), "sha256": _digest(source)},
-        "preview": {"path": str(destination.resolve()), "sha256": _digest(destination)},
-        "projection": "orthographic",
-        "schema": "evidence-render/v2",
-        "views": list(VIEWS),
-    }
-    if args.reference_view:
-        matched = Path(args.reference_out)
-        _save_matched(mesh, colors, REFERENCE_VIEWS[args.reference_view], matched, args.size)
-        result["matched_view"] = {
-            "name": args.reference_view,
-            "path": str(matched.resolve()),
-            "sha256": _digest(matched),
+        matched_stats = None
+        matched_path = None
+        if args.reference_view:
+            matched_path = Path(args.reference_out).resolve()
+            matched = render_view(
+                inputs,
+                args.reference_view,
+                args.size,
+                supersample=args.supersample,
+                limits=limits,
+            )
+            _save_png(matched.image, matched_path)
+            matched_stats = matched.stats
+
+        _, traced_peak = tracemalloc.get_traced_memory()
+        peak_buffer_bytes = max(
+            contact.peak_buffer_bytes,
+            matched_stats.buffer_bytes if matched_stats is not None else 0,
+        )
+        result = {
+            "checks": {
+                "finite_vertices": True,
+                "watertight": bool(mesh.is_watertight),
+                "winding_consistent": bool(mesh.is_winding_consistent),
+            },
+            "dimensions_mm": [round(float(value), 4) for value in mesh.extents],
+            "mesh": {"path": str(source), "sha256": _digest(source)},
+            "performance": {
+                "four_view_seconds": round(contact.elapsed_seconds, 6),
+                "parallel_views": False,
+                "peak_memory_bytes": max(int(traced_peak), peak_buffer_bytes),
+                "processes": 1,
+                "supersample": args.supersample,
+                "triangle_count": count,
+                "views": {stat.view: stat.to_dict() for stat in contact.stats},
+            },
+            "preview": {
+                "path": str(destination),
+                "sha256": _digest(destination),
+            },
+            "projection": "orthographic",
+            "renderer": "cpu-z-buffer/v1",
+            "schema": "evidence-render/v2",
+            "supported_views": list(SUPPORTED_VIEWS),
+            "views": list(CONTACT_VIEWS),
         }
-    payload = json.dumps(result, indent=2)
-    if args.report:
-        report = Path(args.report)
-        report.parent.mkdir(parents=True, exist_ok=True)
-        report.write_text(payload + "\n", encoding="utf-8")
-    print(payload)
-    return 0
+        if matched_path is not None and matched_stats is not None:
+            result["matched_view"] = {
+                "name": args.reference_view,
+                "path": str(matched_path),
+                "sha256": _digest(matched_path),
+            }
+            result["performance"]["single_view_seconds"] = round(
+                matched_stats.elapsed_seconds, 6
+            )
+        payload = json.dumps(result, indent=2)
+        if args.report:
+            report = Path(args.report).resolve()
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(payload + "\n", encoding="utf-8")
+        print(payload)
+        return 0
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+    finally:
+        if not tracing_was_active:
+            tracemalloc.stop()
 
 
 if __name__ == "__main__":

--- a/tests/python/test_cpu_z_buffer.py
+++ b/tests/python/test_cpu_z_buffer.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+import time
+import unittest
+
+import numpy as np
+import trimesh
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = ROOT / "skills"
+if str(SKILLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SKILLS_ROOT))
+
+from cpu_z_buffer import (  # noqa: E402
+    BACKGROUND,
+    CONTACT_VIEWS,
+    SUPPORTED_VIEWS,
+    MeshInput,
+    RenderLimits,
+    render_contact_sheet,
+    render_view,
+)
+
+
+def _box(
+    name: str,
+    extents: tuple[float, float, float],
+    center: tuple[float, float, float],
+    color: tuple[int, int, int],
+) -> MeshInput:
+    transform = np.eye(4)
+    transform[:3, 3] = center
+    mesh = trimesh.creation.box(extents=extents, transform=transform)
+    return MeshInput(name, mesh, color)
+
+
+def _array(rendered) -> np.ndarray:
+    return np.asarray(rendered.image)
+
+
+def _foreground(image: np.ndarray) -> np.ndarray:
+    return np.any(image != np.asarray(BACKGROUND, dtype=np.uint8), axis=2)
+
+
+class CpuZBufferRegressionTests(unittest.TestCase):
+    def test_all_supported_cameras_render_a_stable_region(self) -> None:
+        cube = _box("cube", (4.0, 3.0, 2.0), (0.0, 0.0, 0.0), (120, 170, 210))
+        coverages = {}
+        for view in SUPPORTED_VIEWS:
+            rendered = render_view([cube], view, 192)
+            mask = _foreground(_array(rendered))
+            coverages[view] = float(mask.mean())
+            self.assertGreater(coverages[view], 0.10, view)
+            self.assertLess(coverages[view], 0.90, view)
+            self.assertGreater(rendered.stats.triangles_rasterized, 0, view)
+
+        # Opposite orthographic cameras must agree on the box's outline area.
+        self.assertLess(abs(coverages["top"] - coverages["bottom"]), 0.01)
+        self.assertEqual(CONTACT_VIEWS, ("isometric", "front", "side", "top"))
+
+    def test_double_through_hole_plate_has_no_false_top_face_groove(self) -> None:
+        # Five coplanar solids form a plate with two fully enclosed square holes.
+        # Their top faces contain many independent triangles and shared seams.
+        pieces = [
+            _box("top-rail", (12.0, 2.0, 1.0), (0.0, 2.0, 0.0), (122, 163, 199)),
+            _box("bottom-rail", (12.0, 2.0, 1.0), (0.0, -2.0, 0.0), (122, 163, 199)),
+            _box("left-web", (2.5, 2.0, 1.0), (-4.75, 0.0, 0.0), (122, 163, 199)),
+            _box("center-web", (3.0, 2.0, 1.0), (0.0, 0.0, 0.0), (122, 163, 199)),
+            _box("right-web", (2.5, 2.0, 1.0), (4.75, 0.0, 0.0), (122, 163, 199)),
+        ]
+        image = _array(render_view(pieces, "top", 256))
+        mask = _foreground(image)
+
+        # Flat coplanar faces have one shaded material color: no diagonal line,
+        # triangle shadow, or fake recessed seam is allowed inside the plate.
+        solid_colors = np.unique(image[mask], axis=0)
+        self.assertEqual(len(solid_colors), 1, solid_colors)
+
+        center_y = image.shape[0] // 2
+        self.assertTrue(np.all(image[center_y, 73] == BACKGROUND))
+        self.assertTrue(np.all(image[center_y, 183] == BACKGROUND))
+        self.assertTrue(np.any(image[center_y, 128] != BACKGROUND))
+
+    def test_groove_and_step_keep_their_vertical_occlusion_order(self) -> None:
+        regions = [
+            _box("left-base", (2.0, 2.0, 1.0), (-2.0, 0.0, 0.5), (100, 170, 110)),
+            _box("groove-floor", (2.0, 2.0, 0.3), (0.0, 0.0, 0.15), (60, 110, 220)),
+            _box("right-base", (2.0, 2.0, 1.0), (2.0, 0.0, 0.5), (100, 170, 110)),
+            _box("step", (1.2, 2.0, 1.0), (2.0, 0.0, 1.5), (230, 120, 45)),
+        ]
+        image = _array(render_view(regions, "front", 256))
+        nonwhite = _foreground(image)
+        self.assertGreater(float(nonwhite.mean()), 0.10)
+
+        orange = (image[:, :, 0] > image[:, :, 1] * 1.4) & nonwhite
+        blue = (image[:, :, 2] > image[:, :, 0] * 2.0) & nonwhite
+        green = (image[:, :, 1] > image[:, :, 0] * 1.3) & nonwhite
+        self.assertGreater(int(orange.sum()), 100)
+        self.assertGreater(int(blue.sum()), 100)
+        self.assertGreater(int(green.sum()), 100)
+        self.assertLess(float(np.argwhere(orange)[:, 0].mean()), float(np.argwhere(green)[:, 0].mean()))
+        self.assertGreater(float(np.argwhere(blue)[:, 0].mean()), float(np.argwhere(orange)[:, 0].mean()))
+
+    def test_near_entity_covers_far_entity_even_when_far_is_submitted_last(self) -> None:
+        near = _box("near", (3.0, 0.5, 3.0), (0.0, -2.0, 0.0), (255, 20, 20))
+        far = _box("far", (3.0, 0.5, 3.0), (0.0, 2.0, 0.0), (20, 20, 255))
+        image = _array(render_view([near, far], "front", 192))
+        center = image[96, 96]
+        self.assertGreater(int(center[0]), int(center[2]) * 4, center)
+
+    def test_adjacent_color_regions_have_no_background_crack_or_cross_fill(self) -> None:
+        left = _box("red", (2.0, 3.0, 1.0), (-1.0, 0.0, 0.0), (240, 30, 30))
+        right = _box("blue", (2.0, 3.0, 1.0), (1.0, 0.0, 0.0), (30, 30, 240))
+        image = _array(render_view([left, right], "top", 256))
+        row = image[128]
+        occupied = np.any(row != BACKGROUND, axis=1)
+        indices = np.flatnonzero(occupied)
+        self.assertGreater(len(indices), 100)
+        self.assertTrue(occupied[indices[0] : indices[-1] + 1].all())
+
+        left_half = row[indices[0] : 128]
+        right_half = row[129 : indices[-1] + 1]
+        self.assertGreater(float(np.mean(left_half[:, 0] > left_half[:, 2])), 0.98)
+        self.assertGreater(float(np.mean(right_half[:, 2] > right_half[:, 0])), 0.98)
+
+    def test_limits_fail_closed_and_two_x_is_optional(self) -> None:
+        cube = _box("cube", (1.0, 1.0, 1.0), (0.0, 0.0, 0.0), (120, 170, 210))
+        with self.assertRaisesRegex(ValueError, "configured maximum"):
+            render_view([cube], "top", 128, limits=RenderLimits(max_triangles=11))
+        with self.assertRaisesRegex(ValueError, "supersample"):
+            render_view([cube], "top", 128, supersample=3)
+        with self.assertRaisesRegex(ValueError, "resolution"):
+            render_view(
+                [cube],
+                "top",
+                200,
+                supersample=2,
+                limits=RenderLimits(max_resolution=320),
+            )
+        with self.assertRaisesRegex(ValueError, "between 320 and 2048"):
+            RenderLimits(max_resolution=2049)
+        rendered = render_view([cube], "top", 128, supersample=2)
+        self.assertEqual(rendered.image.size, (128, 128))
+
+    def test_contact_sheet_is_sequential_and_reuses_one_panel_buffer(self) -> None:
+        cube = _box("cube", (1.0, 1.0, 1.0), (0.0, 0.0, 0.0), (120, 170, 210))
+        rendered = render_contact_sheet([cube], 320, title="test")
+        self.assertEqual(rendered.image.size, (320, 320))
+        self.assertEqual([item.view for item in rendered.stats], list(CONTACT_VIEWS))
+        expected_peak = max(item.buffer_bytes for item in rendered.stats)
+        self.assertEqual(rendered.peak_buffer_bytes, expected_peak)
+
+    def test_medium_mesh_runtime_stays_bounded_without_parallel_workers(self) -> None:
+        mesh = trimesh.creation.icosphere(subdivisions=3, radius=2.0)
+        model = MeshInput("medium", mesh, (120, 170, 210))
+        started = time.perf_counter()
+        rendered = render_contact_sheet([model], 320, title="medium")
+        elapsed = time.perf_counter() - started
+        self.assertEqual(rendered.stats[0].triangles_input, len(mesh.faces))
+        self.assertLess(elapsed, 30.0)
+        self.assertLess(rendered.peak_buffer_bytes, 2 * 1024 * 1024)
+
+    def test_renderer_imports_only_headless_cpu_image_dependencies(self) -> None:
+        source = (SKILLS_ROOT / "cpu_z_buffer.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imports = {
+            alias.name.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        imports.update(
+            node.module.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        )
+        self.assertTrue({"numpy", "PIL", "trimesh"}.issubset(imports))
+        self.assertTrue(
+            {"matplotlib", "OpenGL", "pyvista", "pyrender", "multiprocessing"}.isdisjoint(imports)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_text_a3d_printability.py
+++ b/tests/python/test_text_a3d_printability.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hashlib import sha256
 import importlib.util
 import json
 from pathlib import Path
@@ -274,6 +275,20 @@ class PrintabilityGeometryTests(unittest.TestCase):
 
 
 class ContractTests(unittest.TestCase):
+    def test_hash_bound_example_profiles_use_stable_lf_bytes(self):
+        attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8")
+        self.assertIn("*.json text eol=lf", attributes.splitlines())
+
+        for skill_name in ("text-a3d", "text-a3d-color"):
+            examples = ROOT / "skills" / skill_name / "examples"
+            intent = json.loads(
+                (examples / "intent.example.json").read_text(encoding="utf-8")
+            )
+            reference = intent["printability"]["profile"]
+            payload = (examples / reference["path"]).read_bytes()
+            self.assertNotIn(b"\r\n", payload, skill_name)
+            self.assertEqual(sha256(payload).hexdigest(), reference["sha256"])
+
     def test_checked_in_example_contract_is_valid(self):
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary

- replace Matplotlib-based 3D preview rendering with a headless CPU Z-buffer
- use trimesh for mesh loading, NumPy for projection/rasterization/depth buffering, and Pillow for PNG output and contact-sheet composition
- preserve the four-view contact sheet while adding bottom-view support for matched renders
- add cross-platform rendering regressions, performance benchmarks, and Ubuntu/Windows CI coverage

## Motivation

The previous Matplotlib `Poly3DCollection` renderer could introduce triangle-edge shading artifacts and unreliable occlusion in generated four-view PNGs. These artifacts could look like grooves or recessed features and mislead visual inspection by the LLM.

This change uses an explicit depth buffer so nearer surfaces consistently cover farther geometry without relying on a 3D plotting backend.

## Implementation

The CPU rasterizer provides:

- orthographic top, bottom, front, side, and isometric cameras
- backface culling
- orthographic frustum clipping
- off-screen triangle filtering
- triangle screen-bounding-box rasterization in bounded row blocks
- per-pixel depth testing
- sequential four-view rendering with reusable depth and color buffers
- flat face shading without rendered triangle edges
- single-process execution with no multiprocessing
- BLAS thread defaults limited to one
- optional 2x supersampling followed by Pillow downsampling

It does not use OpenGL, EGL, OSMesa, PyVista, pyrender, a GPU, a display server, or a window system.

The implementation uses `pathlib` and avoids POSIX-shell, fork, shared-memory, and Unix-signal assumptions.

## Resource limits

Defaults are intentionally sized for LLM visual inspection:

- four-view output: 640 × 640
- supersampling: 1x
- internal view limit: 1280 pixels
- triangle limit: 500,000
- processes: 1
- parallel view rendering: disabled

Built-in hard limits are:

- maximum internal resolution: 2048 pixels
- maximum triangles: 2,000,000
- maximum supersampling: 2x

## Regression coverage

The Python regression suite covers:

- a dual-through-hole plate with no false top-face grooves
- groove and step visibility/occlusion
- front/back overlapping entities
- adjacent multi-color regions without background cracks or cross-fill
- top, bottom, front, side, and isometric cameras
- resource-limit failures and optional 2x supersampling
- sequential buffer reuse
- bounded medium-mesh rendering

Tests compare silhouettes, coverage, color regions, and tolerances rather than exact PNG bytes.

## Performance

Local 320 px, 1x benchmark:

| Workload | Triangles | Single view | Four views | Peak memory |
| --- | ---: | ---: | ---: | ---: |
| Small | 12 | 0.004 s | 0.005 s | 2.17 MiB |
| Medium | 1,280 | 0.046 s | 0.169 s | 2.60 MiB |
| Large | 20,480 | 0.670 s | 2.315 s | 14.87 MiB |

The benchmark records per-view/four-view time, peak memory, and triangle counts. Performance improvements should prioritize clipping and rasterization efficiency rather than multiprocessing.

## Validation

- `npm run test:python` — 9 tests passed
- `npm test` — 45 tests passed
- `npm run typecheck`
- `npm run licenses:check`
- `npm audit --audit-level=high`
- `npm run build`

GitHub Actions now runs the CPU renderer regression suite and benchmark on both `ubuntu-latest` and `windows-latest`.

Closes #6