### PR TITLE
fix: use UTF-8 for parameter subprocess

### DIFF
--- a/server/model-parameters.ts
+++ b/server/model-parameters.ts
@@ -71,7 +71,11 @@ async function runJsonProcess(
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(executable, args, {
       cwd: options.cwd,
-      env: options.env ?? process.env,
+      env: {
+        ...process.env,
+        ...options.env,
+        PYTHONUTF8: '1',
+      },
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdout = '';


### PR DESCRIPTION
## Summary

- force UTF-8 mode for the bounded CAD parameter Python subprocess
- preserve the existing process environment and per-build overrides
- allow supported localized `label_zh` / `group_zh` source metadata to round-trip on native Windows

Closes #13.

## Validation

- focused localized inspection/rewrite tests: 2 passed on native Windows without an externally set `PYTHONUTF8`
- `npm run typecheck`
- `npm run build`
- `npm run licenses:check` (388 production packages)
- full `npm test`: 54 passed / 6 host-limited failures, improving from 52 passed / 8 failures on the frozen base; the two resolved failures are the localized parameter cases targeted by this patch
- `git diff --check`

The remaining local failures are unrelated Windows path-separator/symlink assertions and a host system-font parsing failure inside build123d. The exact base's Linux verify and Linux/Windows renderer CI checks are green.
