### PR TITLE
fix: scope PYTHONIOENCODING to inspector/rewriter protocol only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,15 @@ jobs:
           python-version: '3.12'
           cache: pip
       - run: python -m pip install --disable-pip-version-check --requirement requirements.txt
+      - uses: actions/setup-node@v4
+        if: runner.os == 'Windows'
+        with:
+          node-version: '22.19.0'
+          cache: npm
+      - run: npm ci
+        if: runner.os == 'Windows'
+      - run: node --import tsx --test tests/model-parameters.test.ts
+        if: runner.os == 'Windows'
       - run: python -m unittest discover -s tests/python -p "test_*.py"
       - run: python scripts/benchmark_cpu_z_buffer.py --resolution 320 --large-subdivisions 4 --out cpu-z-buffer-benchmark.json
       - uses: actions/upload-artifact@v4

--- a/server/model-parameters.ts
+++ b/server/model-parameters.ts
@@ -96,11 +96,7 @@ async function runJsonProcess(
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(executable, args, {
       cwd: options.cwd,
-      env: {
-        ...process.env,
-        ...options.env,
-        PYTHONUTF8: '1',
-      },
+      env: options.env ?? process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdout = '';
@@ -154,7 +150,12 @@ async function parameterSource(
   let parsed: ParameterSourceResponse;
   try {
     parsed = JSON.parse(
-      await runJsonProcess(pythonExecutable, [PARAMETER_SOURCE_SCRIPT], input),
+      await runJsonProcess(
+        pythonExecutable,
+        [PARAMETER_SOURCE_SCRIPT],
+        input,
+        { env: { PYTHONIOENCODING: 'utf-8' } },
+      ),
     ) as ParameterSourceResponse;
   } catch (error) {
     throw new ParameterBuildError(

--- a/server/model-parameters.ts
+++ b/server/model-parameters.ts
@@ -154,7 +154,7 @@ async function parameterSource(
         pythonExecutable,
         [PARAMETER_SOURCE_SCRIPT],
         input,
-        { env: { PYTHONIOENCODING: 'utf-8' } },
+        { env: { ...process.env, PYTHONIOENCODING: 'utf-8' } },
       ),
     ) as ParameterSourceResponse;
   } catch (error) {

--- a/server/model-parameters.ts
+++ b/server/model-parameters.ts
@@ -96,7 +96,11 @@ async function runJsonProcess(
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(executable, args, {
       cwd: options.cwd,
-      env: options.env ?? process.env,
+      env: {
+        ...process.env,
+        ...options.env,
+        PYTHONUTF8: '1',
+      },
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdout = '';

--- a/tests/model-parameters.test.ts
+++ b/tests/model-parameters.test.ts
@@ -259,7 +259,14 @@ output.mkdir(parents=True, exist_ok=True)
 stl = output / "model.stl"
 step = output / "model.step"
 display_glb = output / "model-display.glb"
-stl.write_text(f"solid {SIZE}\\nendsolid model\\n", encoding="utf-8")
+environment = (
+    f"PYTHONIOENCODING={os.environ.get('PYTHONIOENCODING')};"
+    f"PYTHONUTF8={os.environ.get('PYTHONUTF8')}"
+)
+stl.write_text(
+    f"solid {SIZE} {environment}\\nendsolid model\\n",
+    encoding="utf-8",
+)
 step.write_text(f"ISO-10303-21 {SIZE}\\n", encoding="utf-8")
 display_glb.write_bytes(b"glTF" + bytes(str(SIZE), encoding="utf-8"))
 digest = lambda path: hashlib.sha256(path.read_bytes()).hexdigest()
@@ -534,6 +541,41 @@ test('rebuilds the complete model in staging and commits source only after succe
       committedStep,
     );
   } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test('scopes protocol encoding without changing model build environment', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'amagine-parameter-encoding-'));
+  const previousIoEncoding = process.env.PYTHONIOENCODING;
+  const previousUtf8 = process.env.PYTHONUTF8;
+  try {
+    process.env.PYTHONIOENCODING = 'ascii';
+    delete process.env.PYTHONUTF8;
+    await writeInitialBuild(root);
+    const [model] = await parameterModelsForWorkspace(root, PYTHON);
+    assert.ok(model);
+    assert.equal(model.parameters[0]?.labelZh, '局部偏移');
+    assert.equal(model.parameters[0]?.groupZh, '局部特征');
+    await rebuildModelWithParameters({
+      pythonExecutable: PYTHON,
+      request: {
+        primaryPreviewPath: model.primaryPreviewPath,
+        sourceHash: model.sourceHash,
+        sourcePath: model.sourcePath,
+        values: { 'local-offset': -1.5 },
+      },
+      workspaceRoot: root,
+    });
+    assert.match(
+      await readFile(join(root, 'model.stl'), 'utf8'),
+      /solid -1\.5 PYTHONIOENCODING=ascii;PYTHONUTF8=None/u,
+    );
+  } finally {
+    if (previousIoEncoding === undefined) delete process.env.PYTHONIOENCODING;
+    else process.env.PYTHONIOENCODING = previousIoEncoding;
+    if (previousUtf8 === undefined) delete process.env.PYTHONUTF8;
+    else process.env.PYTHONUTF8 = previousUtf8;
     await rm(root, { force: true, recursive: true });
   }
 });


### PR DESCRIPTION
## Summary

Addresses the encoding-scope feedback on #14 (related issue: #13).

- Set `PYTHONIOENCODING=utf-8` only for the parameter inspector/rewriter JSON protocol.
- Preserve the inherited process environment when applying that protocol override.
- Leave the shared subprocess helper and CAD rebuild file-encoding defaults unchanged; do not force `PYTHONUTF8`.
- Add a localized-parameter regression with inherited `PYTHONIOENCODING=ascii`, including assertions that the model rebuild retains its original encoding environment.
- Run the focused Node parameter tests in the existing Windows CPU-renderer CI job, as requested in review, using the existing action versions and dependency manifests.

## Validation

Latest follow-up: `8d68ad1` (native Windows, Node 24.14.1, Python 3.13.13).

- Focused parameter tests: 4 passed, 3 skipped, both with the default environment and inherited `PYTHONIOENCODING=ascii`.
- `npm run typecheck`: passed.
- `npm run build`: passed, with the existing Vite large-chunk warning.
- `npm run licenses:check`: passed for 388 production packages.
- `git diff --check`: passed.
- Full `npm test`: 55 passed, 3 failed, 3 skipped. The same three failures occur on the previous #16 head: two Windows path-separator assertions and a symlink-creation `EPERM` restriction. They are outside this patch. The three real CAD helper tests are skipped because the isolated worktree has no project-local Python environment.

The new encoding regression covers the global-UTF8 problem from #14; it already passes the previous #16 head and is not claimed as independent proof of the inherited-environment merge. The latter is the narrowly scoped `...process.env` addition at the protocol call site. No real model provider was invoked.
